### PR TITLE
chore: Claude Code 훅 및 스킬 예시 파일 추가

### DIFF
--- a/Fantasy-server/.claude/hooks/postToolUse.sh
+++ b/Fantasy-server/.claude/hooks/postToolUse.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# .claude/hooks/postToolUse.sh
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ "$TOOL_NAME" != "Edit" && "$TOOL_NAME" != "Write" ]]; then
+    exit 0
+fi
+
+if [[ "$FILE_PATH" != *.cs ]]; then
+    exit 0
+fi
+
+echo "[Hook] C# file modified: $FILE_PATH" >&2
+
+dotnet format --no-restore 2>/dev/null || echo "[Hook] format failed (ignored)" >&2
+
+CACHE_FILE=".claude/.last_build_hash"
+
+# git HEAD 대신 실제 .cs 파일 내용 해시 사용 → 편집마다 올바르게 감지
+CURRENT_HASH=$(find . -name "*.cs" -not -path "*/obj/*" | sort | xargs md5sum 2>/dev/null | md5sum | cut -d' ' -f1)
+
+LAST_HASH=""
+if [[ -f "$CACHE_FILE" ]]; then
+    LAST_HASH=$(cat "$CACHE_FILE")
+fi
+
+if [[ "$CURRENT_HASH" != "$LAST_HASH" ]]; then
+    echo "[Hook] Running dotnet build..." >&2
+    if dotnet build --no-restore; then
+        echo "$CURRENT_HASH" > "$CACHE_FILE"
+    else
+        echo "[Hook] Build failed" >&2
+        exit 2
+    fi
+else
+    echo "[Hook] Skip build (no source changes)" >&2
+fi
+
+echo "[Hook] Running tests..." >&2
+if dotnet test --no-build --verbosity minimal; then
+    echo "[Hook] Tests passed" >&2
+else
+    echo "[Hook] Tests failed" >&2
+    exit 2
+fi
+
+exit 0

--- a/Fantasy-server/.claude/hooks/preToolUse.sh
+++ b/Fantasy-server/.claude/hooks/preToolUse.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[[ "$TOOL_NAME" != "Bash" ]] && exit 0
+
+NORMALIZED=$(echo "$COMMAND" | tr -s ' ' | tr -d '\n')
+
+DANGEROUS_KEYWORDS=(
+    "rm -rf"
+    "mkfs"
+    "dd if="
+    "shutdown"
+    "reboot"
+    "kill -9 -1"
+    ":(){"
+    "> /dev/sda"
+    "chmod -R 777 /"
+    "chown -R root"
+)
+
+for keyword in "${DANGEROUS_KEYWORDS[@]}"; do
+    if [[ "$NORMALIZED" == *"$keyword"* ]]; then
+        echo "[Hook] ✗ Blocked dangerous keyword: $keyword" >&2
+        echo "Command: $COMMAND" >&2
+        exit 2
+    fi
+done
+
+# rm -rf /  or  rm -rf *
+if [[ "$NORMALIZED" =~ rm[[:space:]]+-rf.*(/|\*) ]]; then
+    echo "[Hook] ✗ Blocked root/wildcard deletion" >&2
+    exit 2
+fi
+
+# curl/wget → pipe/redirect → sh/bash
+if [[ "$NORMALIZED" =~ (curl|wget).*(\||>).*(sh|bash) ]]; then
+    echo "[Hook] ✗ Blocked remote execution" >&2
+    exit 2
+fi
+
+exit 0

--- a/Fantasy-server/.claude/skills/commit/SKILL.md
+++ b/Fantasy-server/.claude/skills/commit/SKILL.md
@@ -16,6 +16,7 @@ Create Git commits following the project's commit conventions.
 - `feat` — new feature added
 - `fix` — bug fix, missing config, or missing DI registration
 - `update` — modification to existing code
+- `chore` — tooling, CI/CD, dependency updates, config changes unrelated to app logic
 
 **Description rules**:
 - Written in **Korean**
@@ -29,6 +30,8 @@ feat: 로그인 로직 추가
 fix: 세션 DI 누락 수정
 update: Account 엔터티 수정
 ```
+
+See `.claude/skills/commit/examples/type-guide.md` for a boundary-rule table and real scenarios from this project.
 
 **Do NOT**:
 - Add Claude as co-author

--- a/Fantasy-server/.claude/skills/commit/examples/type-guide.md
+++ b/Fantasy-server/.claude/skills/commit/examples/type-guide.md
@@ -1,0 +1,82 @@
+# Commit Type Guide — Fantasy Server
+
+## feat — New capability added to the codebase
+
+Use when creating new files is the primary change.
+
+**Examples from this project:**
+
+| Change | Commit message |
+|---|---|
+| Add LoginService.cs, LogoutService.cs | `feat: 로그인·로그아웃 서비스 추가` |
+| Add AuthController.cs | `feat: Auth 컨트롤러 추가` |
+| Add RefreshTokenRedisRepository.cs | `feat: 리프레시 토큰 Redis 레포지토리 추가` |
+| Add new Entity class | `feat: {EntityName} 엔터티 추가` |
+| Add new test class | `feat: {ServiceName} 테스트 추가` |
+| Add new migration file | `feat: {MigrationName} 마이그레이션 추가` |
+
+---
+
+## fix — Broken behavior or missing registration/config corrected
+
+Use when existing code is wrong, or a required wiring (DI, config key, middleware) is absent.
+Adding only a DI registration line without adding the service file itself is also `fix`.
+
+**Examples from this project:**
+
+| Change | Commit message |
+|---|---|
+| Add missing `services.AddScoped<IAccountRepository, AccountRepository>()` in `Program.cs` | `fix: IAccountRepository DI 누락 수정` |
+| Fix wrong prefix on Redis key | `fix: Redis 리프레시 토큰 키 prefix 수정` |
+| Remove misconfigured EF Core ValueGeneration | `fix: UpdatedAt 자동 생성 설정 제거` |
+| Fix typo in port value in `appsettings.json` | `fix: 개발 환경 DB 포트 수정` |
+| Fix password comparison using HashPassword instead of BCrypt.Verify | `fix: 비밀번호 검증 로직 수정` |
+
+---
+
+## update — Existing code modified without adding a new capability
+
+Use when modifying files that already exist — renaming, restructuring, adjusting behavior, etc.
+
+**Examples from this project:**
+
+| Change | Commit message |
+|---|---|
+| Change response type from `T` to `CommonApiResponse<T>` | `update: Auth 응답 타입을 CommonApiResponse로 변경` |
+| Move JwtProvider to a different namespace | `update: JwtProvider를 Jwt 네임스페이스로 이동` |
+| Update port/connection string in appsettings | `update: Docker 서비스 이름 통일 및 연결 문자열 수정` |
+| Modify a property on an existing Entity | `update: Account 엔터티 수정` |
+| Add a test method to an existing test class | `update: LoginService 테스트 추가` |
+| Merge CI workflow steps | `update: CI 워크플로우 빌드·테스트 단계 통합` |
+
+---
+
+## Boundary rules
+
+| Situation | Type |
+|---|---|
+| New `.cs` service/repository/controller file added | `feat` |
+| New method added to an existing `.cs` file | `update` |
+| DI registration line added alone, no new service file (`Program.cs`, `*Config.cs`) | `fix` |
+| New service file + its DI registration added together | `feat` (same logical unit) |
+| New migration file added | `feat` |
+| Existing migration file corrected (column issue) | `fix` |
+| New test class added | `feat` |
+| Test method added to an existing test class | `update` |
+| Refactoring without behavior change | `update` |
+
+---
+
+## When to split into multiple commits
+
+If a branch mixes new features with unrelated bug fixes, split them:
+
+```
+# New service + its DI registration → one logical unit, commit together
+git add Domain/Auth/Service/LoginService.cs Domain/Auth/Config/AuthServiceConfig.cs
+git commit -m "feat: 로그인 서비스 추가"
+
+# Separate Redis key bug fix → independent fix
+git add Domain/Auth/Repository/RefreshTokenRedisRepository.cs
+git commit -m "fix: 리프레시 토큰 Redis 키 prefix 수정"
+```

--- a/Fantasy-server/.claude/skills/db-migrate/examples/naming.md
+++ b/Fantasy-server/.claude/skills/db-migrate/examples/naming.md
@@ -1,0 +1,75 @@
+# Migration Naming Guide — Fantasy Server
+
+## Format
+
+**PascalCase**, no spaces, clearly describes the schema operation being performed.
+
+---
+
+## Naming patterns by operation
+
+### New table
+```
+Create{TableName}Table
+```
+e.g. `CreateAccountTable`, `CreateGameRoomTable`, `CreatePlayerTable`
+
+### Initial schema (multiple tables at once)
+```
+CreateTables
+InitialSchema
+```
+e.g. `CreateTables` ← the actual name of the first migration in this project
+
+### Add column to existing table
+```
+Add{ColumnName}To{TableName}
+```
+e.g. `AddNicknameToAccount`, `AddStatusToGameRoom`, `AddRefreshTokenToAuth`
+
+### Remove column
+```
+Remove{ColumnName}From{TableName}
+```
+e.g. `RemoveDeprecatedFieldFromAccount`
+
+### Fix column type, constraint, or misconfiguration
+```
+Fix{ColumnName}{Issue}
+Change{ColumnName}In{TableName}
+```
+e.g.
+- `FixUpdatedAtValueGeneration` ← actual fix migration in this project
+- `ChangeEmailMaxLengthInAccount`
+
+### Add index
+```
+Add{Description}IndexTo{TableName}
+```
+e.g. `AddEmailUniqueIndexToAccount`, `AddCreatedAtIndexToGameRoom`
+
+### Add foreign key
+```
+Add{Relation}ForeignKeyTo{TableName}
+```
+e.g. `AddAccountForeignKeyToGamePlayer`
+
+---
+
+## Anti-patterns (avoid)
+
+| Bad | Good |
+|---|---|
+| `Migration1` | `CreateAccountTable` |
+| `FixAccount` | `FixUpdatedAtValueGeneration` |
+| `UpdateSchema` | `AddNicknameToAccount` |
+| `Temp` | (describe what actually changed) |
+| `Fix` | `FixEmailConstraintInAccount` |
+
+---
+
+## Migration history in this project
+
+| Migration name | What it does |
+|---|---|
+| _(no migrations yet)_ | First migration should be named `CreateTables` |

--- a/Fantasy-server/.claude/skills/pr/SKILL.md
+++ b/Fantasy-server/.claude/skills/pr/SKILL.md
@@ -151,6 +151,7 @@ Format: `{type}: {Korean description}`
 - `fix` — bug fix or missing configuration/DI registration
 - `update` — modification to existing code
 - `refactor` — refactoring without behavior change
+- `chore` — tooling, CI/CD, dependency updates, config changes unrelated to app logic
 
 **Rules:**
 - Description in Korean
@@ -162,32 +163,15 @@ Format: `{type}: {Korean description}`
 - `fix: Key Vault 연동 방식을 AddAzureKeyVault으로 변경`
 - `refactor: 로그인 로직 리팩토링`
 
+See `.claude/skills/pr/examples/feature-to-develop.md` for a complete example (title options + filled body) of a feature → develop PR.
+
 ---
 
 ## PR Body Template
 
 Follow this exact structure (keep the emoji headers as-is):
 
-```
-## 📚작업 내용
-
-- {change item 1}
-- {change item 2}
-
-## ◀️참고 사항
-
-{additional notes, context, before/after comparisons if relevant. Write "." if nothing to add.}
-
-## ✅체크리스트
-
-> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.
-
-- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
-- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?
-
-
-> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*
-```
+!.claude/skills/pr/templates/pr-body.md
 
 **Rules:**
 - Analyze commits and diffs to fill in `작업 내용` with a concise bullet list

--- a/Fantasy-server/.claude/skills/pr/SKILL.md
+++ b/Fantasy-server/.claude/skills/pr/SKILL.md
@@ -122,13 +122,13 @@ rm PR_BODY.md
 [full body preview]
 ```
 
-**Step 5. Ask the user** using AskUserQuestion:
-> "어떤 제목을 사용할까요? (1 / 2 / 3 또는 직접 입력)"
+**Step 5. Ask the user** using AskUserQuestion with a `choices` array:
+- Options: the 3 generated titles + "직접 입력" as the last option
+- If the user selects "직접 입력", ask a follow-up AskUserQuestion for the custom title
 
 **Step 6. Create PR to `develop`**
 
-- If the user answered 1, 2, or 3, use the corresponding suggested title
-- If the user typed a custom title, use it as-is
+- Use the selected title, or the custom title if the user chose "직접 입력"
 
 ```bash
 gh pr create --title "{chosen title}" --body-file PR_BODY.md --base develop

--- a/Fantasy-server/.claude/skills/pr/SKILL.md
+++ b/Fantasy-server/.claude/skills/pr/SKILL.md
@@ -12,8 +12,11 @@ Generate a PR based on the current branch. Behavior differs depending on the bra
 ### Step 0. Initialize & Branch Discovery
 1. Identify the current branch using `git branch --show-current`.
 2. **Check for Arguments**:
-  - **If an argument is provided (e.g., `/pr {target}`)**: Set `{target}` as the **Base Branch** and proceed directly to **Case 3**.
-  - **If no argument is provided**: Follow the **Branch-Based Behavior** below.
+  - **If an argument is provided (e.g., `/pr {target}`)**: Set `{Base Branch}` = `{target}` and proceed directly to **Case 3**.
+  - **If no argument is provided**: Follow the **Branch-Based Behavior** below:
+    - Current branch is `develop` → **Case 1**
+    - Current branch matches `release/x.x.x` → **Case 2**
+    - Any other branch → **Case 3** with `{Base Branch}` = `develop`
 
 ---
 
@@ -98,11 +101,11 @@ rm PR_BODY.md
 
 ### Case 3: Any other branch
 
-**Step 1. Analyze changes from `develop`**
+**Step 1. Analyze changes from `{Base Branch}`**
 
-- Commits: `git log develop..HEAD --oneline`
-- Diff stats: `git diff develop...HEAD --stat`
-- Detailed diff: `git diff develop...HEAD`
+- Commits: `git log {Base Branch}..HEAD --oneline`
+- Diff stats: `git diff {Base Branch}...HEAD --stat`
+- Detailed diff: `git diff {Base Branch}...HEAD`
 
 **Step 2. Suggest three PR titles** following the PR Title Convention below
 
@@ -126,12 +129,12 @@ rm PR_BODY.md
 - Options: the 3 generated titles + "직접 입력" as the last option
 - If the user selects "직접 입력", ask a follow-up AskUserQuestion for the custom title
 
-**Step 6. Create PR to `develop`**
+**Step 6. Create PR to `{Base Branch}`**
 
 - Use the selected title, or the custom title if the user chose "직접 입력"
 
 ```bash
-gh pr create --title "{chosen title}" --body-file PR_BODY.md --base develop
+gh pr create --title "{chosen title}" --body-file PR_BODY.md --base {Base Branch}
 ```
 
 **Step 7. Delete PR_BODY.md**

--- a/Fantasy-server/.claude/skills/pr/examples/feature-to-develop.md
+++ b/Fantasy-server/.claude/skills/pr/examples/feature-to-develop.md
@@ -1,0 +1,49 @@
+# Example: Feature Branch PR (feature → develop)
+
+## Branch context
+
+- Current branch: `feat/auth-api`
+- Base branch: `develop`
+
+## Suggested PR titles (3 options)
+
+1. `feature: JWT 기반 로그인·로그아웃 API 추가`
+2. `feature: Auth 도메인 로그인·로그아웃 엔드포인트 구현`
+3. `feature: 로그인·리프레시토큰·로그아웃 서비스 추가`
+
+## Completed PR body example
+
+---
+
+## 📚작업 내용
+
+- LoginService 구현 — 이메일·비밀번호 검증 및 JWT 발급
+- LogoutService 구현 — Redis 리프레시 토큰 삭제
+- RefreshTokenRedisRepository 추가 — Redis key: `refresh:{accountId}`, TTL 30일
+- AuthController 추가 — `POST /v1/auth/login`, `POST /v1/auth/logout`
+- 로그인 엔드포인트에 `"login"` RateLimit 정책 적용
+
+## ◀️참고 사항
+
+액세스 토큰 만료 시간은 `appsettings.json`의 `Jwt:AccessTokenExpirationMinutes` 값을 사용합니다.
+로그아웃은 리프레시 토큰만 삭제하며, 액세스 토큰은 만료 전까지 유효합니다.
+
+## ✅체크리스트
+
+> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.
+
+- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
+- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?
+
+
+> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*
+
+---
+
+## Writing rules
+
+- **작업 내용 bullets**: group by meaningful change, not by raw commit
+- **참고 사항**: configuration notes, before/after comparisons, etc. Use `"."` if nothing to add
+- Keep the total body under 2500 characters
+- All text content in Korean (keep section header emojis as-is)
+- No emojis in body text — section headers only

--- a/Fantasy-server/.claude/skills/pr/templates/pr-body.md
+++ b/Fantasy-server/.claude/skills/pr/templates/pr-body.md
@@ -1,0 +1,18 @@
+## 📚작업 내용
+
+- {change item 1}
+- {change item 2}
+
+## ◀️참고 사항
+
+{additional notes, context, before/after comparisons if relevant. Write "." if nothing to add.}
+
+## ✅체크리스트
+
+> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.
+
+- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
+- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?
+
+
+> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*

--- a/Fantasy-server/.claude/skills/test/examples/filter-patterns.md
+++ b/Fantasy-server/.claude/skills/test/examples/filter-patterns.md
@@ -1,0 +1,71 @@
+# Test Filter Patterns — Fantasy Server
+
+## How filtering works
+
+```bash
+dotnet test --filter "FullyQualifiedName~{value}"
+```
+
+The `~` operator matches any fully qualified test name that **contains** the value as a substring.
+
+Fully qualified name format:
+```
+{Namespace}.{OuterClass}+{InnerClass}.{MethodName}
+```
+
+Example:
+```
+Fantasy.Test.Account.Service.CreateAccountServiceTests+이메일이_존재하지_않을_때.회원가입_요청_시_계정이_저장된다
+```
+
+**Korean class and method names work as-is. No escaping required.**
+
+---
+
+## Current test classes in this project
+
+| `/test` argument | What runs |
+|---|---|
+| _(no argument)_ | All tests |
+| `CreateAccountServiceTests` | All CreateAccountService tests |
+| `DeleteAccountServiceTests` | All DeleteAccountService tests (currently empty) |
+| `LoginServiceTests` | All LoginService tests |
+| `이메일이_존재하지_않을_때` | Email-not-found scenario (CreateAccount) |
+| `이미_사용중인_이메일일_때` | Duplicate email scenario (CreateAccount) |
+| `유효한_자격증명일_때` | Valid credentials scenario (Login) |
+| `존재하지_않는_이메일일_때` | Email-not-found scenario (Login) |
+| `잘못된_비밀번호일_때` | Wrong password scenario (Login) |
+
+---
+
+## Pattern examples
+
+### Filter by outer class — runs all tests for a service
+```
+/test CreateAccountServiceTests
+```
+→ Matches all of `Fantasy.Test.Account.Service.CreateAccountServiceTests+*.*`
+
+### Filter by Korean inner class — runs all tests in a scenario
+```
+/test 이메일이_존재하지_않을_때
+```
+→ Matches all methods inside that inner class
+
+### Filter by method name — runs a single test
+```
+/test 회원가입_요청_시_비밀번호가_해싱된다
+```
+→ Matches the single method by name substring
+
+### Filter by domain
+```
+/test LoginService
+```
+→ Matches all of `Fantasy.Test.Auth.Service.LoginServiceTests+*.*`
+
+### Filter by namespace — runs an entire domain
+```
+/test Fantasy.Test.Account
+```
+→ Matches everything under the Account namespace


### PR DESCRIPTION
## 📚작업 내용

- preToolUse 훅 추가 — 위험한 Bash 명령어 사전 차단 (rm -rf, curl pipe to sh 등)
- postToolUse 훅 추가 — C# 파일 수정 시 자동으로 dotnet format·build·test 실행
- commit 스킬 타입 가이드 추가 — `chore` 타입 정의 및 예시 파일(type-guide.md) 작성
- pr 스킬 업데이트 — `chore` 타입 추가, PR 본문 템플릿 파일 분리, feature 예시 파일 추가
- db-migrate 스킬 예시 추가 — 마이그레이션 네이밍 가이드(naming.md) 작성
- test 스킬 예시 추가 — 필터 패턴 가이드(filter-patterns.md) 작성

## ◀️참고 사항

postToolUse 훅은 .cs 파일이 변경될 때만 동작하며, 빌드 결과를 해시로 캐싱하여 변경이 없을 경우 빌드를 건너뜁니다.
preToolUse 훅은 Bash 도구 호출에만 적용됩니다.

## ✅체크리스트

> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.

- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?


> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*