### PR TITLE
feat: 리프레시 토큰 로테이션 및 재사용 감지 구현

### DIFF
--- a/Fantasy-server/.claude/skills/pr/SKILL.md
+++ b/Fantasy-server/.claude/skills/pr/SKILL.md
@@ -112,20 +112,7 @@ rm PR_BODY.md
 **Step 3. Write PR body** following the PR Body Template below
 - Save to `PR_BODY.md`
 
-**Step 4. Output** in this format:
-```
-## 추천 PR 제목
-
-1. [title1]
-2. [title2]
-3. [title3]
-
-## PR 본문 (PR_BODY.md에 저장됨)
-
-[full body preview]
-```
-
-**Step 5. Ask the user** using AskUserQuestion with a `choices` array:
+**Step 4. Ask the user** using AskUserQuestion with a `choices` array:
 - Options: the 3 generated titles + "직접 입력" as the last option
 - If the user selects "직접 입력", ask a follow-up AskUserQuestion for the custom title
 

--- a/Fantasy-server/Fantasy.Server/Domain/Account/Repository/AccountRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Account/Repository/AccountRepository.cs
@@ -19,6 +19,11 @@ public class AccountRepository : IAccountRepository
             .AsNoTracking()
             .FirstOrDefaultAsync(a => a.Email == email);
 
+    public async Task<AccountEntity?> FindByIdAsync(long id)
+        => await _db.Accounts
+            .AsNoTracking()
+            .FirstOrDefaultAsync(a => a.Id == id);
+
     public async Task<AccountEntity> SaveAsync(AccountEntity account)
     {
         var entry = _db.Accounts.Entry(account);

--- a/Fantasy-server/Fantasy.Server/Domain/Account/Repository/Interface/IAccountRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Account/Repository/Interface/IAccountRepository.cs
@@ -5,6 +5,7 @@ namespace Fantasy.Server.Domain.Account.Repository.Interface;
 public interface IAccountRepository
 {
     Task<AccountEntity?> FindByEmailAsync(string email);
+    Task<AccountEntity?> FindByIdAsync(long id);
     Task<AccountEntity> SaveAsync(AccountEntity account);
     Task<bool> ExistsByEmailAsync(string email);
     Task DeleteAsync(AccountEntity account);

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Controller/AuthController.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Controller/AuthController.cs
@@ -42,7 +42,6 @@ public class AuthController : ControllerBase
         return CommonApiResponse.Success("로그아웃 성공.");
     }
 
-    [Authorize]
     [HttpPost("refresh")]
     public async Task<CommonApiResponse<TokenResponse>> Refresh([FromBody] RefreshTokenRequest request)
     {

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Enum/RotateResult.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Enum/RotateResult.cs
@@ -1,0 +1,8 @@
+namespace Fantasy.Server.Domain.Auth.Enum;
+
+public enum RotateResult
+{
+    NotFound = 0,
+    Reused   = -1,
+    Success  = 1
+}

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/Interface/IRefreshTokenRedisRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/Interface/IRefreshTokenRedisRepository.cs
@@ -3,6 +3,8 @@ namespace Fantasy.Server.Domain.Auth.Repository.Interface;
 public interface IRefreshTokenRedisRepository
 {
     Task SaveAsync(long id, string token, TimeSpan ttl);
+    Task<bool> RotateAsync(long id, string expectedOldToken, string newToken, TimeSpan ttl);
     Task<string?> FindByIdAsync(long id);
+    Task<long?> FindIdByTokenAsync(string token);
     Task DeleteAsync(long id);
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/Interface/IRefreshTokenRedisRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/Interface/IRefreshTokenRedisRepository.cs
@@ -6,7 +6,5 @@ public interface IRefreshTokenRedisRepository
 {
     Task SaveAsync(long id, string token, TimeSpan ttl);
     Task<RotateResult> RotateAsync(long id, string expectedOldToken, string newToken, TimeSpan ttl);
-    Task<string?> FindByIdAsync(long id);
-    Task<long?> FindIdByTokenAsync(string token);
     Task DeleteAsync(long id);
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/Interface/IRefreshTokenRedisRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/Interface/IRefreshTokenRedisRepository.cs
@@ -1,9 +1,11 @@
+using Fantasy.Server.Domain.Auth.Enum;
+
 namespace Fantasy.Server.Domain.Auth.Repository.Interface;
 
 public interface IRefreshTokenRedisRepository
 {
     Task SaveAsync(long id, string token, TimeSpan ttl);
-    Task<bool> RotateAsync(long id, string expectedOldToken, string newToken, TimeSpan ttl);
+    Task<RotateResult> RotateAsync(long id, string expectedOldToken, string newToken, TimeSpan ttl);
     Task<string?> FindByIdAsync(long id);
     Task<long?> FindIdByTokenAsync(string token);
     Task DeleteAsync(long id);

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/RefreshTokenRedisRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/RefreshTokenRedisRepository.cs
@@ -7,15 +7,9 @@ namespace Fantasy.Server.Domain.Auth.Repository;
 public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
 {
     private const string Prefix = "fantasy:";
-    private static readonly string ReverseKeyPrefix = $"{Prefix}refresh:token:";
 
     private static readonly LuaScript SaveScript = LuaScript.Prepare(@"
-        local old = redis.call('GET', @forwardKey)
-        if old then
-            redis.call('DEL', @reverseKeyPrefix .. old)
-        end
         redis.call('SET', @forwardKey, @token, 'EX', @ttl)
-        redis.call('SET', @reverseKey, @id,    'EX', @ttl)
         return 1
     ");
 
@@ -26,25 +20,9 @@ public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
         end
         if current ~= @expectedOldToken then
             redis.call('DEL', @forwardKey)
-            redis.call('DEL', @reverseKeyPrefix .. current)
             return -1
         end
-        local reverseId = redis.call('GET', @oldReverseKey)
-        if not reverseId or reverseId ~= @id then
-            return 0
-        end
-        redis.call('DEL', @oldReverseKey)
-        redis.call('SET', @forwardKey,    @newToken, 'EX', @ttl)
-        redis.call('SET', @newReverseKey, @id,       'EX', @ttl)
-        return 1
-    ");
-
-    private static readonly LuaScript DeleteScript = LuaScript.Prepare(@"
-        local token = redis.call('GET', @forwardKey)
-        if token then
-            redis.call('DEL', @reverseKeyPrefix .. token)
-        end
-        redis.call('DEL', @forwardKey)
+        redis.call('SET', @forwardKey, @newToken, 'EX', @ttl)
         return 1
     ");
 
@@ -56,18 +34,14 @@ public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
     }
 
     private static string ForwardKey(long id) => $"{Prefix}refresh:{id}";
-    private static string ReverseKey(string token) => $"{ReverseKeyPrefix}{token}";
 
     public async Task SaveAsync(long id, string token, TimeSpan ttl)
     {
         await _db.ScriptEvaluateAsync(SaveScript, new
         {
-            forwardKey       = (RedisKey)ForwardKey(id),
-            reverseKey       = (RedisKey)ReverseKey(token),
-            reverseKeyPrefix = (RedisValue)ReverseKeyPrefix,
-            token            = (RedisValue)token,
-            id               = (RedisValue)id.ToString(),
-            ttl              = (RedisValue)(long)ttl.TotalSeconds
+            forwardKey = (RedisKey)ForwardKey(id),
+            token      = (RedisValue)token,
+            ttl        = (RedisValue)(long)ttl.TotalSeconds
         });
     }
 
@@ -76,39 +50,14 @@ public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
         var result = await _db.ScriptEvaluateAsync(RotateScript, new
         {
             forwardKey       = (RedisKey)ForwardKey(id),
-            oldReverseKey    = (RedisKey)ReverseKey(expectedOldToken),
-            newReverseKey    = (RedisKey)ReverseKey(newToken),
-            reverseKeyPrefix = (RedisValue)ReverseKeyPrefix,
             expectedOldToken = (RedisValue)expectedOldToken,
             newToken         = (RedisValue)newToken,
-            id               = (RedisValue)id.ToString(),
             ttl              = (RedisValue)(long)ttl.TotalSeconds
         });
 
         return (RotateResult)(int)(long)result;
     }
 
-    public async Task<string?> FindByIdAsync(long id)
-    {
-        var value = await _db.StringGetAsync(ForwardKey(id));
-        return value.HasValue ? value.ToString() : null;
-    }
-
-    public async Task<long?> FindIdByTokenAsync(string token)
-    {
-        var value = await _db.StringGetAsync(ReverseKey(token));
-        if (!value.HasValue) return null;
-        if (!long.TryParse(value.ToString(), out var id))
-            throw new InvalidOperationException($"Redis 역방향 키에 저장된 값이 올바른 계정 ID 형식이 아닙니다: token={token}");
-        return id;
-    }
-
     public async Task DeleteAsync(long id)
-    {
-        await _db.ScriptEvaluateAsync(DeleteScript, new
-        {
-            forwardKey       = (RedisKey)ForwardKey(id),
-            reverseKeyPrefix = (RedisValue)ReverseKeyPrefix
-        });
-    }
+        => await _db.KeyDeleteAsync(ForwardKey(id));
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/RefreshTokenRedisRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/RefreshTokenRedisRepository.cs
@@ -1,29 +1,101 @@
 using Fantasy.Server.Domain.Auth.Repository.Interface;
-using Microsoft.Extensions.Caching.Distributed;
+using StackExchange.Redis;
 
 namespace Fantasy.Server.Domain.Auth.Repository;
 
 public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
 {
-    private readonly IDistributedCache _cache;
+    private const string Prefix = "fantasy:";
+    private readonly IDatabase _db;
 
-    public RefreshTokenRedisRepository(IDistributedCache cache)
+    public RefreshTokenRedisRepository(IConnectionMultiplexer multiplexer)
     {
-        _cache = cache;
+        _db = multiplexer.GetDatabase();
     }
+
+    private static string ForwardKey(long id) => $"{Prefix}refresh:{id}";
+    private static string ReverseKey(string token) => $"{Prefix}refresh:token:{token}";
 
     public async Task SaveAsync(long id, string token, TimeSpan ttl)
     {
-        var options = new DistributedCacheEntryOptions
+        var script = LuaScript.Prepare(@"
+            local old = redis.call('GET', @forwardKey)
+            if old then
+                redis.call('DEL', '" + Prefix + @"refresh:token:' .. old)
+            end
+            redis.call('SET', @forwardKey, @token, 'EX', @ttl)
+            redis.call('SET', @reverseKey, @id,    'EX', @ttl)
+            return 1
+        ");
+
+        await _db.ScriptEvaluateAsync(script, new
         {
-            AbsoluteExpirationRelativeToNow = ttl
-        };
-        await _cache.SetStringAsync($"refresh:{id}", token, options);
+            forwardKey = (RedisKey)ForwardKey(id),
+            reverseKey = (RedisKey)ReverseKey(token),
+            token = (RedisValue)token,
+            id    = (RedisValue)id.ToString(),
+            ttl   = (RedisValue)(long)ttl.TotalSeconds
+        });
+    }
+
+    public async Task<bool> RotateAsync(long id, string expectedOldToken, string newToken, TimeSpan ttl)
+    {
+        var script = LuaScript.Prepare(@"
+            local current = redis.call('GET', @forwardKey)
+            if not current or current ~= @expectedOldToken then
+                return 0
+            end
+            local reverseId = redis.call('GET', @oldReverseKey)
+            if not reverseId or reverseId ~= @id then
+                return 0
+            end
+            redis.call('DEL', @oldReverseKey)
+            redis.call('SET', @forwardKey,    @newToken, 'EX', @ttl)
+            redis.call('SET', @newReverseKey, @id,       'EX', @ttl)
+            return 1
+        ");
+
+        var result = await _db.ScriptEvaluateAsync(script, new
+        {
+            forwardKey    = (RedisKey)ForwardKey(id),
+            oldReverseKey = (RedisKey)ReverseKey(expectedOldToken),
+            newReverseKey = (RedisKey)ReverseKey(newToken),
+            expectedOldToken = (RedisValue)expectedOldToken,
+            newToken      = (RedisValue)newToken,
+            id            = (RedisValue)id.ToString(),
+            ttl           = (RedisValue)(long)ttl.TotalSeconds
+        });
+
+        return (long)result == 1;
     }
 
     public async Task<string?> FindByIdAsync(long id)
-        => await _cache.GetStringAsync($"refresh:{id}");
+    {
+        var value = await _db.StringGetAsync(ForwardKey(id));
+        return value.HasValue ? value.ToString() : null;
+    }
+
+    public async Task<long?> FindIdByTokenAsync(string token)
+    {
+        var value = await _db.StringGetAsync(ReverseKey(token));
+        if (!value.HasValue) return null;
+        return long.TryParse(value.ToString(), out var id) ? id : null;
+    }
 
     public async Task DeleteAsync(long id)
-        => await _cache.RemoveAsync($"refresh:{id}");
+    {
+        var script = LuaScript.Prepare(@"
+            local token = redis.call('GET', @forwardKey)
+            if token then
+                redis.call('DEL', '" + Prefix + @"refresh:token:' .. token)
+            end
+            redis.call('DEL', @forwardKey)
+            return 1
+        ");
+
+        await _db.ScriptEvaluateAsync(script, new
+        {
+            forwardKey = (RedisKey)ForwardKey(id)
+        });
+    }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/RefreshTokenRedisRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/RefreshTokenRedisRepository.cs
@@ -6,6 +6,42 @@ namespace Fantasy.Server.Domain.Auth.Repository;
 public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
 {
     private const string Prefix = "fantasy:";
+    private static readonly string ReverseKeyPrefix = $"{Prefix}refresh:token:";
+
+    private static readonly LuaScript SaveScript = LuaScript.Prepare(@"
+        local old = redis.call('GET', @forwardKey)
+        if old then
+            redis.call('DEL', @reverseKeyPrefix .. old)
+        end
+        redis.call('SET', @forwardKey, @token, 'EX', @ttl)
+        redis.call('SET', @reverseKey, @id,    'EX', @ttl)
+        return 1
+    ");
+
+    private static readonly LuaScript RotateScript = LuaScript.Prepare(@"
+        local current = redis.call('GET', @forwardKey)
+        if not current or current ~= @expectedOldToken then
+            return 0
+        end
+        local reverseId = redis.call('GET', @oldReverseKey)
+        if not reverseId or reverseId ~= @id then
+            return 0
+        end
+        redis.call('DEL', @oldReverseKey)
+        redis.call('SET', @forwardKey,    @newToken, 'EX', @ttl)
+        redis.call('SET', @newReverseKey, @id,       'EX', @ttl)
+        return 1
+    ");
+
+    private static readonly LuaScript DeleteScript = LuaScript.Prepare(@"
+        local token = redis.call('GET', @forwardKey)
+        if token then
+            redis.call('DEL', @reverseKeyPrefix .. token)
+        end
+        redis.call('DEL', @forwardKey)
+        return 1
+    ");
+
     private readonly IDatabase _db;
 
     public RefreshTokenRedisRepository(IConnectionMultiplexer multiplexer)
@@ -14,56 +50,32 @@ public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
     }
 
     private static string ForwardKey(long id) => $"{Prefix}refresh:{id}";
-    private static string ReverseKey(string token) => $"{Prefix}refresh:token:{token}";
+    private static string ReverseKey(string token) => $"{ReverseKeyPrefix}{token}";
 
     public async Task SaveAsync(long id, string token, TimeSpan ttl)
     {
-        var script = LuaScript.Prepare(@"
-            local old = redis.call('GET', @forwardKey)
-            if old then
-                redis.call('DEL', '" + Prefix + @"refresh:token:' .. old)
-            end
-            redis.call('SET', @forwardKey, @token, 'EX', @ttl)
-            redis.call('SET', @reverseKey, @id,    'EX', @ttl)
-            return 1
-        ");
-
-        await _db.ScriptEvaluateAsync(script, new
+        await _db.ScriptEvaluateAsync(SaveScript, new
         {
-            forwardKey = (RedisKey)ForwardKey(id),
-            reverseKey = (RedisKey)ReverseKey(token),
-            token = (RedisValue)token,
-            id    = (RedisValue)id.ToString(),
-            ttl   = (RedisValue)(long)ttl.TotalSeconds
+            forwardKey       = (RedisKey)ForwardKey(id),
+            reverseKey       = (RedisKey)ReverseKey(token),
+            reverseKeyPrefix = (RedisValue)ReverseKeyPrefix,
+            token            = (RedisValue)token,
+            id               = (RedisValue)id.ToString(),
+            ttl              = (RedisValue)(long)ttl.TotalSeconds
         });
     }
 
     public async Task<bool> RotateAsync(long id, string expectedOldToken, string newToken, TimeSpan ttl)
     {
-        var script = LuaScript.Prepare(@"
-            local current = redis.call('GET', @forwardKey)
-            if not current or current ~= @expectedOldToken then
-                return 0
-            end
-            local reverseId = redis.call('GET', @oldReverseKey)
-            if not reverseId or reverseId ~= @id then
-                return 0
-            end
-            redis.call('DEL', @oldReverseKey)
-            redis.call('SET', @forwardKey,    @newToken, 'EX', @ttl)
-            redis.call('SET', @newReverseKey, @id,       'EX', @ttl)
-            return 1
-        ");
-
-        var result = await _db.ScriptEvaluateAsync(script, new
+        var result = await _db.ScriptEvaluateAsync(RotateScript, new
         {
-            forwardKey    = (RedisKey)ForwardKey(id),
-            oldReverseKey = (RedisKey)ReverseKey(expectedOldToken),
-            newReverseKey = (RedisKey)ReverseKey(newToken),
+            forwardKey       = (RedisKey)ForwardKey(id),
+            oldReverseKey    = (RedisKey)ReverseKey(expectedOldToken),
+            newReverseKey    = (RedisKey)ReverseKey(newToken),
             expectedOldToken = (RedisValue)expectedOldToken,
-            newToken      = (RedisValue)newToken,
-            id            = (RedisValue)id.ToString(),
-            ttl           = (RedisValue)(long)ttl.TotalSeconds
+            newToken         = (RedisValue)newToken,
+            id               = (RedisValue)id.ToString(),
+            ttl              = (RedisValue)(long)ttl.TotalSeconds
         });
 
         return (long)result == 1;
@@ -79,23 +91,17 @@ public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
     {
         var value = await _db.StringGetAsync(ReverseKey(token));
         if (!value.HasValue) return null;
-        return long.TryParse(value.ToString(), out var id) ? id : null;
+        if (!long.TryParse(value.ToString(), out var id))
+            throw new InvalidOperationException($"Redis 역방향 키에 저장된 값이 올바른 계정 ID 형식이 아닙니다: token={token}");
+        return id;
     }
 
     public async Task DeleteAsync(long id)
     {
-        var script = LuaScript.Prepare(@"
-            local token = redis.call('GET', @forwardKey)
-            if token then
-                redis.call('DEL', '" + Prefix + @"refresh:token:' .. token)
-            end
-            redis.call('DEL', @forwardKey)
-            return 1
-        ");
-
-        await _db.ScriptEvaluateAsync(script, new
+        await _db.ScriptEvaluateAsync(DeleteScript, new
         {
-            forwardKey = (RedisKey)ForwardKey(id)
+            forwardKey       = (RedisKey)ForwardKey(id),
+            reverseKeyPrefix = (RedisValue)ReverseKeyPrefix
         });
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/RefreshTokenRedisRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/RefreshTokenRedisRepository.cs
@@ -1,3 +1,4 @@
+using Fantasy.Server.Domain.Auth.Enum;
 using Fantasy.Server.Domain.Auth.Repository.Interface;
 using StackExchange.Redis;
 
@@ -20,8 +21,13 @@ public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
 
     private static readonly LuaScript RotateScript = LuaScript.Prepare(@"
         local current = redis.call('GET', @forwardKey)
-        if not current or current ~= @expectedOldToken then
+        if not current then
             return 0
+        end
+        if current ~= @expectedOldToken then
+            redis.call('DEL', @forwardKey)
+            redis.call('DEL', @reverseKeyPrefix .. current)
+            return -1
         end
         local reverseId = redis.call('GET', @oldReverseKey)
         if not reverseId or reverseId ~= @id then
@@ -65,20 +71,21 @@ public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
         });
     }
 
-    public async Task<bool> RotateAsync(long id, string expectedOldToken, string newToken, TimeSpan ttl)
+    public async Task<RotateResult> RotateAsync(long id, string expectedOldToken, string newToken, TimeSpan ttl)
     {
         var result = await _db.ScriptEvaluateAsync(RotateScript, new
         {
             forwardKey       = (RedisKey)ForwardKey(id),
             oldReverseKey    = (RedisKey)ReverseKey(expectedOldToken),
             newReverseKey    = (RedisKey)ReverseKey(newToken),
+            reverseKeyPrefix = (RedisValue)ReverseKeyPrefix,
             expectedOldToken = (RedisValue)expectedOldToken,
             newToken         = (RedisValue)newToken,
             id               = (RedisValue)id.ToString(),
             ttl              = (RedisValue)(long)ttl.TotalSeconds
         });
 
-        return (long)result == 1;
+        return (RotateResult)(int)(long)result;
     }
 
     public async Task<string?> FindByIdAsync(long id)

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Service/LoginService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Service/LoginService.cs
@@ -39,7 +39,7 @@ public class LoginService : ILoginService
             throw new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다.");
 
         var accessToken = _jwtProvider.GenerateAccessToken(account);
-        var refreshToken = _jwtProvider.GenerateRefreshToken();
+        var refreshToken = _jwtProvider.GenerateRefreshToken(account.Id);
 
         await _refreshTokenRepository.SaveAsync(account.Id, refreshToken, RefreshTokenTtl);
 

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Service/RefreshTokenService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Service/RefreshTokenService.cs
@@ -1,9 +1,9 @@
+using Fantasy.Server.Domain.Account.Repository.Interface;
 using Fantasy.Server.Domain.Auth.Dto.Request;
 using Fantasy.Server.Domain.Auth.Dto.Response;
 using Fantasy.Server.Domain.Auth.Repository.Interface;
 using Fantasy.Server.Domain.Auth.Service.Interface;
 using Fantasy.Server.Global.Security.Jwt;
-using Fantasy.Server.Global.Security.Provider;
 using Gamism.SDK.Extensions.AspNetCore.Exceptions;
 
 namespace Fantasy.Server.Domain.Auth.Service;
@@ -12,18 +12,18 @@ public class RefreshTokenService : IRefreshTokenService
 {
     private static readonly TimeSpan RefreshTokenTtl = TimeSpan.FromDays(30);
 
-    private readonly ICurrentUserProvider _currentUserProvider;
+    private readonly IAccountRepository _accountRepository;
     private readonly IRefreshTokenRedisRepository _refreshTokenRepository;
     private readonly IJwtProvider _jwtProvider;
     private readonly int _accessTokenExpirationMinutes;
 
     public RefreshTokenService(
-        ICurrentUserProvider currentUserProvider,
+        IAccountRepository accountRepository,
         IRefreshTokenRedisRepository refreshTokenRepository,
         IJwtProvider jwtProvider,
         IConfiguration configuration)
     {
-        _currentUserProvider = currentUserProvider;
+        _accountRepository = accountRepository;
         _refreshTokenRepository = refreshTokenRepository;
         _jwtProvider = jwtProvider;
         _accessTokenExpirationMinutes = int.Parse(
@@ -32,23 +32,25 @@ public class RefreshTokenService : IRefreshTokenService
 
     public async Task<TokenResponse> ExecuteAsync(RefreshTokenRequest request)
     {
-        var account = await _currentUserProvider.GetAccountAsync();
-
-        var stored = await _refreshTokenRepository.FindByIdAsync(account.Id)
+        var accountId = await _refreshTokenRepository.FindIdByTokenAsync(request.RefreshToken)
             ?? throw new UnauthorizedException("리프레시 토큰을 찾을 수 없습니다.");
 
-        if (stored != request.RefreshToken)
-            throw new UnauthorizedException("리프레시 토큰이 올바르지 않습니다.");
+        var account = await _accountRepository.FindByIdAsync(accountId)
+            ?? throw new UnauthorizedException("인증 정보를 찾을 수 없습니다.");
 
         var accessToken = _jwtProvider.GenerateAccessToken(account);
-        var refreshToken = _jwtProvider.GenerateRefreshToken();
+        var newRefreshToken = _jwtProvider.GenerateRefreshToken();
 
-        await _refreshTokenRepository.SaveAsync(account.Id, refreshToken, RefreshTokenTtl);
+        var rotated = await _refreshTokenRepository.RotateAsync(
+            account.Id, request.RefreshToken, newRefreshToken, RefreshTokenTtl);
+
+        if (!rotated)
+            throw new UnauthorizedException("리프레시 토큰이 이미 사용되었거나 올바르지 않습니다.");
 
         var accessTokenExpiresAt = DateTimeOffset.UtcNow
             .AddMinutes(_accessTokenExpirationMinutes)
             .ToUnixTimeSeconds();
 
-        return new TokenResponse(accessToken, refreshToken, accessTokenExpiresAt);
+        return new TokenResponse(accessToken, newRefreshToken, accessTokenExpiresAt);
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Service/RefreshTokenService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Service/RefreshTokenService.cs
@@ -33,14 +33,13 @@ public class RefreshTokenService : IRefreshTokenService
 
     public async Task<TokenResponse> ExecuteAsync(RefreshTokenRequest request)
     {
-        var accountId = await _refreshTokenRepository.FindIdByTokenAsync(request.RefreshToken)
-            ?? throw new UnauthorizedException("리프레시 토큰을 찾을 수 없습니다.");
+        var accountId = ParseAccountId(request.RefreshToken);
 
         var account = await _accountRepository.FindByIdAsync(accountId)
             ?? throw new UnauthorizedException("인증 정보를 찾을 수 없습니다.");
 
         var accessToken = _jwtProvider.GenerateAccessToken(account);
-        var newRefreshToken = _jwtProvider.GenerateRefreshToken();
+        var newRefreshToken = _jwtProvider.GenerateRefreshToken(account.Id);
 
         var rotateResult = await _refreshTokenRepository.RotateAsync(
             account.Id, request.RefreshToken, newRefreshToken, RefreshTokenTtl);
@@ -58,5 +57,17 @@ public class RefreshTokenService : IRefreshTokenService
             .ToUnixTimeSeconds();
 
         return new TokenResponse(accessToken, newRefreshToken, accessTokenExpiresAt);
+    }
+
+    private static long ParseAccountId(string token)
+    {
+        var separatorIndex = token.IndexOf(':');
+        if (separatorIndex <= 0)
+            throw new UnauthorizedException("유효하지 않은 리프레시 토큰입니다.");
+
+        if (!long.TryParse(token[..separatorIndex], out var accountId))
+            throw new UnauthorizedException("유효하지 않은 리프레시 토큰입니다.");
+
+        return accountId;
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Service/RefreshTokenService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Service/RefreshTokenService.cs
@@ -34,15 +34,10 @@ public class RefreshTokenService : IRefreshTokenService
     public async Task<TokenResponse> ExecuteAsync(RefreshTokenRequest request)
     {
         var accountId = ParseAccountId(request.RefreshToken);
-
-        var account = await _accountRepository.FindByIdAsync(accountId)
-            ?? throw new UnauthorizedException("인증 정보를 찾을 수 없습니다.");
-
-        var accessToken = _jwtProvider.GenerateAccessToken(account);
-        var newRefreshToken = _jwtProvider.GenerateRefreshToken(account.Id);
+        var newRefreshToken = _jwtProvider.GenerateRefreshToken(accountId);
 
         var rotateResult = await _refreshTokenRepository.RotateAsync(
-            account.Id, request.RefreshToken, newRefreshToken, RefreshTokenTtl);
+            accountId, request.RefreshToken, newRefreshToken, RefreshTokenTtl);
 
         switch (rotateResult)
         {
@@ -51,6 +46,11 @@ public class RefreshTokenService : IRefreshTokenService
             case RotateResult.NotFound:
                 throw new UnauthorizedException("리프레시 토큰을 찾을 수 없습니다.");
         }
+
+        var account = await _accountRepository.FindByIdAsync(accountId)
+            ?? throw new UnauthorizedException("인증 정보를 찾을 수 없습니다.");
+
+        var accessToken = _jwtProvider.GenerateAccessToken(account);
 
         var accessTokenExpiresAt = DateTimeOffset.UtcNow
             .AddMinutes(_accessTokenExpirationMinutes)

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Service/RefreshTokenService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Service/RefreshTokenService.cs
@@ -1,6 +1,7 @@
 using Fantasy.Server.Domain.Account.Repository.Interface;
 using Fantasy.Server.Domain.Auth.Dto.Request;
 using Fantasy.Server.Domain.Auth.Dto.Response;
+using Fantasy.Server.Domain.Auth.Enum;
 using Fantasy.Server.Domain.Auth.Repository.Interface;
 using Fantasy.Server.Domain.Auth.Service.Interface;
 using Fantasy.Server.Global.Security.Jwt;
@@ -41,11 +42,16 @@ public class RefreshTokenService : IRefreshTokenService
         var accessToken = _jwtProvider.GenerateAccessToken(account);
         var newRefreshToken = _jwtProvider.GenerateRefreshToken();
 
-        var rotated = await _refreshTokenRepository.RotateAsync(
+        var rotateResult = await _refreshTokenRepository.RotateAsync(
             account.Id, request.RefreshToken, newRefreshToken, RefreshTokenTtl);
 
-        if (!rotated)
-            throw new UnauthorizedException("리프레시 토큰이 이미 사용되었거나 올바르지 않습니다.");
+        switch (rotateResult)
+        {
+            case RotateResult.Reused:
+                throw new UnauthorizedException("토큰 재사용이 감지되었습니다.");
+            case RotateResult.NotFound:
+                throw new UnauthorizedException("리프레시 토큰을 찾을 수 없습니다.");
+        }
 
         var accessTokenExpiresAt = DateTimeOffset.UtcNow
             .AddMinutes(_accessTokenExpirationMinutes)

--- a/Fantasy-server/Fantasy.Server/Global/Config/DatabaseConfig.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Config/DatabaseConfig.cs
@@ -10,7 +10,7 @@ public static class DatabaseConfig
         IConfiguration configuration)
     {
         var connectionString = configuration.GetConnectionString("Database")
-            ?? throw new InvalidOperationException("Database connection string is missing.");
+            ?? throw new InvalidOperationException("데이터베이스 연결 문자열이 설정되지 않았습니다.");
 
         services.AddDbContext<AppDbContext>(options =>
             options.UseNpgsql(connectionString));

--- a/Fantasy-server/Fantasy.Server/Global/Config/JwtConfig.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Config/JwtConfig.cs
@@ -11,11 +11,11 @@ public static class JwtConfig
         IConfiguration configuration)
     {
         var secretKey = configuration["Jwt:SecretKey"]
-            ?? throw new InvalidOperationException("JWT secret key is missing.");
+            ?? throw new InvalidOperationException("JWT 시크릿 키가 설정되지 않았습니다.");
         var issuer = configuration["Jwt:Issuer"]
-            ?? throw new InvalidOperationException("JWT issuer is missing.");
+            ?? throw new InvalidOperationException("JWT 발급자가 설정되지 않았습니다.");
         var audience = configuration["Jwt:Audience"]
-            ?? throw new InvalidOperationException("JWT audience is missing.");
+            ?? throw new InvalidOperationException("JWT 대상이 설정되지 않았습니다.");
 
         services.AddAuthentication(options =>
         {

--- a/Fantasy-server/Fantasy.Server/Global/Config/RedisConfig.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Config/RedisConfig.cs
@@ -10,7 +10,7 @@ public static class RedisConfig
         string instanceName)
     {
         var connectionString = configuration.GetConnectionString("Redis")
-            ?? throw new InvalidOperationException("Redis connection string is missing.");
+            ?? throw new InvalidOperationException("Redis 연결 문자열이 설정되지 않았습니다.");
 
         services.AddSingleton<IConnectionMultiplexer>(
             ConnectionMultiplexer.Connect(connectionString));

--- a/Fantasy-server/Fantasy.Server/Global/Security/Jwt/IJwtProvider.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Security/Jwt/IJwtProvider.cs
@@ -5,5 +5,5 @@ namespace Fantasy.Server.Global.Security.Jwt;
 public interface IJwtProvider
 {
     string GenerateAccessToken(Account account);
-    string GenerateRefreshToken();
+    string GenerateRefreshToken(long accountId);
 }

--- a/Fantasy-server/Fantasy.Server/Global/Security/Jwt/JwtProvider.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Security/Jwt/JwtProvider.cs
@@ -17,11 +17,11 @@ public class JwtProvider : IJwtProvider
     public JwtProvider(IConfiguration configuration)
     {
         var secretKey = configuration["Jwt:SecretKey"]
-            ?? throw new InvalidOperationException("JWT secret key is missing.");
+            ?? throw new InvalidOperationException("JWT 시크릿 키가 설정되지 않았습니다.");
         _issuer = configuration["Jwt:Issuer"]
-            ?? throw new InvalidOperationException("JWT issuer is missing.");
+            ?? throw new InvalidOperationException("JWT 발급자가 설정되지 않았습니다.");
         _audience = configuration["Jwt:Audience"]
-            ?? throw new InvalidOperationException("JWT audience is missing.");
+            ?? throw new InvalidOperationException("JWT 대상이 설정되지 않았습니다.");
         _accessTokenExpirationMinutes = int.Parse(
             configuration["Jwt:AccessTokenExpirationMinutes"] ?? "15");
 

--- a/Fantasy-server/Fantasy.Server/Global/Security/Jwt/JwtProvider.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Security/Jwt/JwtProvider.cs
@@ -54,9 +54,9 @@ public class JwtProvider : IJwtProvider
         return new JwtSecurityTokenHandler().WriteToken(token);
     }
 
-    public string GenerateRefreshToken()
+    public string GenerateRefreshToken(long accountId)
     {
         var bytes = RandomNumberGenerator.GetBytes(64);
-        return Convert.ToBase64String(bytes);
+        return $"{accountId}:{Convert.ToBase64String(bytes)}";
     }
 }

--- a/Fantasy-server/Fantasy.Test/Auth/Service/LoginServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Auth/Service/LoginServiceTests.cs
@@ -28,7 +28,7 @@ public class LoginServiceTests
             var account = AccountEntity.Create(_request.Email, BCrypt.Net.BCrypt.HashPassword(_request.Password));
             _accountRepository.FindByEmailAsync(_request.Email).Returns(account);
             _jwtProvider.GenerateAccessToken(account).Returns("access-token");
-            _jwtProvider.GenerateRefreshToken().Returns("refresh-token");
+            _jwtProvider.GenerateRefreshToken(Arg.Any<long>()).Returns("refresh-token");
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
             _sut = new LoginService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }
@@ -49,7 +49,7 @@ public class LoginServiceTests
             await _sut.ExecuteAsync(_request);
 
             await _refreshTokenRepository.Received(1)
-                .SaveAsync(Arg.Any<long>(), "refresh-token", TimeSpan.FromDays(30));
+                .SaveAsync(Arg.Any<long>(), Arg.Any<string>(), TimeSpan.FromDays(30));
         }
     }
 

--- a/Fantasy-server/Fantasy.Test/Auth/Service/RefreshTokenServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Auth/Service/RefreshTokenServiceTests.cs
@@ -1,5 +1,6 @@
 using Fantasy.Server.Domain.Account.Repository.Interface;
 using Fantasy.Server.Domain.Auth.Dto.Request;
+using Fantasy.Server.Domain.Auth.Enum;
 using Fantasy.Server.Domain.Auth.Repository.Interface;
 using Fantasy.Server.Domain.Auth.Service;
 using Fantasy.Server.Global.Security.Jwt;
@@ -36,7 +37,7 @@ public class RefreshTokenServiceTests
             _accountRepository.FindByIdAsync(AccountId).Returns(_account);
             _refreshTokenRepository
                 .RotateAsync(_account.Id, RefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
-                .Returns(true);
+                .Returns(RotateResult.Success);
             _jwtProvider.GenerateAccessToken(_account).Returns("new-access-token");
             _jwtProvider.GenerateRefreshToken().Returns("new-refresh-token");
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
@@ -114,7 +115,7 @@ public class RefreshTokenServiceTests
         }
     }
 
-    public class RotateAsync가_실패할_때
+    public class RotateAsync가_NotFound를_반환할_때
     {
         private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
         private readonly IRefreshTokenRedisRepository _refreshTokenRepository = Substitute.For<IRefreshTokenRedisRepository>();
@@ -124,13 +125,13 @@ public class RefreshTokenServiceTests
         private readonly AccountEntity _account = CreateAccount();
         private readonly RefreshTokenRequest _request = new(RefreshToken);
 
-        public RotateAsync가_실패할_때()
+        public RotateAsync가_NotFound를_반환할_때()
         {
             _refreshTokenRepository.FindIdByTokenAsync(RefreshToken).Returns(AccountId);
             _accountRepository.FindByIdAsync(AccountId).Returns(_account);
             _refreshTokenRepository
                 .RotateAsync(_account.Id, RefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
-                .Returns(false);
+                .Returns(RotateResult.NotFound);
             _jwtProvider.GenerateAccessToken(_account).Returns("new-access-token");
             _jwtProvider.GenerateRefreshToken().Returns("new-refresh-token");
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
@@ -142,7 +143,41 @@ public class RefreshTokenServiceTests
         {
             var act = async () => await _sut.ExecuteAsync(_request);
 
-            await act.Should().ThrowAsync<UnauthorizedException>();
+            await act.Should().ThrowAsync<UnauthorizedException>()
+                .WithMessage("리프레시 토큰을 찾을 수 없습니다.");
+        }
+    }
+
+    public class RotateAsync가_Reused를_반환할_때
+    {
+        private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
+        private readonly IRefreshTokenRedisRepository _refreshTokenRepository = Substitute.For<IRefreshTokenRedisRepository>();
+        private readonly IJwtProvider _jwtProvider = Substitute.For<IJwtProvider>();
+        private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
+        private readonly RefreshTokenService _sut;
+        private readonly AccountEntity _account = CreateAccount();
+        private readonly RefreshTokenRequest _request = new(RefreshToken);
+
+        public RotateAsync가_Reused를_반환할_때()
+        {
+            _refreshTokenRepository.FindIdByTokenAsync(RefreshToken).Returns(AccountId);
+            _accountRepository.FindByIdAsync(AccountId).Returns(_account);
+            _refreshTokenRepository
+                .RotateAsync(_account.Id, RefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
+                .Returns(RotateResult.Reused);
+            _jwtProvider.GenerateAccessToken(_account).Returns("new-access-token");
+            _jwtProvider.GenerateRefreshToken().Returns("new-refresh-token");
+            _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
+            _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
+        }
+
+        [Fact]
+        public async Task 토큰_갱신_요청_시_UnauthorizedException이_발생한다()
+        {
+            var act = async () => await _sut.ExecuteAsync(_request);
+
+            await act.Should().ThrowAsync<UnauthorizedException>()
+                .WithMessage("토큰 재사용이 감지되었습니다.");
         }
     }
 }

--- a/Fantasy-server/Fantasy.Test/Auth/Service/RefreshTokenServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Auth/Service/RefreshTokenServiceTests.cs
@@ -15,8 +15,8 @@ namespace Fantasy.Test.Auth.Service;
 
 public class RefreshTokenServiceTests
 {
-    private const string RefreshToken = "valid-refresh-token";
-    private const long AccountId = 1L;
+    // AccountEntity.Create(...)로 생성된 엔티티의 Id는 DB 할당 전이므로 기본값 0
+    private const string ValidRefreshToken = "0:valid-refresh-token";
 
     private static AccountEntity CreateAccount()
         => AccountEntity.Create("user@example.com", "hashed_password");
@@ -29,17 +29,16 @@ public class RefreshTokenServiceTests
         private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
         private readonly RefreshTokenService _sut;
         private readonly AccountEntity _account = CreateAccount();
-        private readonly RefreshTokenRequest _request = new(RefreshToken);
+        private readonly RefreshTokenRequest _request = new(ValidRefreshToken);
 
         public 유효한_리프레시_토큰으로_요청할_때()
         {
-            _refreshTokenRepository.FindIdByTokenAsync(RefreshToken).Returns(AccountId);
-            _accountRepository.FindByIdAsync(AccountId).Returns(_account);
+            _accountRepository.FindByIdAsync(_account.Id).Returns(_account);
             _refreshTokenRepository
-                .RotateAsync(_account.Id, RefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
+                .RotateAsync(_account.Id, ValidRefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
                 .Returns(RotateResult.Success);
             _jwtProvider.GenerateAccessToken(_account).Returns("new-access-token");
-            _jwtProvider.GenerateRefreshToken().Returns("new-refresh-token");
+            _jwtProvider.GenerateRefreshToken(Arg.Any<long>()).Returns("new-refresh-token");
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
             _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }
@@ -60,32 +59,40 @@ public class RefreshTokenServiceTests
             await _sut.ExecuteAsync(_request);
 
             await _refreshTokenRepository.Received(1)
-                .RotateAsync(_account.Id, RefreshToken, "new-refresh-token", TimeSpan.FromDays(30));
+                .RotateAsync(_account.Id, ValidRefreshToken, "new-refresh-token", TimeSpan.FromDays(30));
         }
     }
 
-    public class Redis에_리프레시_토큰이_없을_때
+    public class 유효하지_않은_토큰_형식일_때
     {
         private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
         private readonly IRefreshTokenRedisRepository _refreshTokenRepository = Substitute.For<IRefreshTokenRedisRepository>();
         private readonly IJwtProvider _jwtProvider = Substitute.For<IJwtProvider>();
         private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
         private readonly RefreshTokenService _sut;
-        private readonly RefreshTokenRequest _request = new("unknown-token");
 
-        public Redis에_리프레시_토큰이_없을_때()
+        public 유효하지_않은_토큰_형식일_때()
         {
-            _refreshTokenRepository.FindIdByTokenAsync("unknown-token").Returns((long?)null);
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
             _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }
 
         [Fact]
-        public async Task 토큰_갱신_요청_시_UnauthorizedException이_발생한다()
+        public async Task 콜론이_없는_토큰으로_요청_시_UnauthorizedException이_발생한다()
         {
-            var act = async () => await _sut.ExecuteAsync(_request);
+            var act = async () => await _sut.ExecuteAsync(new RefreshTokenRequest("invalidtoken"));
 
-            await act.Should().ThrowAsync<UnauthorizedException>();
+            await act.Should().ThrowAsync<UnauthorizedException>()
+                .WithMessage("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        [Fact]
+        public async Task accountId가_숫자가_아닌_토큰으로_요청_시_UnauthorizedException이_발생한다()
+        {
+            var act = async () => await _sut.ExecuteAsync(new RefreshTokenRequest("abc:sometoken"));
+
+            await act.Should().ThrowAsync<UnauthorizedException>()
+                .WithMessage("유효하지 않은 리프레시 토큰입니다.");
         }
     }
 
@@ -96,12 +103,10 @@ public class RefreshTokenServiceTests
         private readonly IJwtProvider _jwtProvider = Substitute.For<IJwtProvider>();
         private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
         private readonly RefreshTokenService _sut;
-        private readonly RefreshTokenRequest _request = new(RefreshToken);
 
         public 계정이_존재하지_않을_때()
         {
-            _refreshTokenRepository.FindIdByTokenAsync(RefreshToken).Returns(AccountId);
-            _accountRepository.FindByIdAsync(AccountId).Returns((AccountEntity?)null);
+            _accountRepository.FindByIdAsync(Arg.Any<long>()).Returns((AccountEntity?)null);
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
             _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }
@@ -109,9 +114,10 @@ public class RefreshTokenServiceTests
         [Fact]
         public async Task 토큰_갱신_요청_시_UnauthorizedException이_발생한다()
         {
-            var act = async () => await _sut.ExecuteAsync(_request);
+            var act = async () => await _sut.ExecuteAsync(new RefreshTokenRequest(ValidRefreshToken));
 
-            await act.Should().ThrowAsync<UnauthorizedException>();
+            await act.Should().ThrowAsync<UnauthorizedException>()
+                .WithMessage("인증 정보를 찾을 수 없습니다.");
         }
     }
 
@@ -123,17 +129,15 @@ public class RefreshTokenServiceTests
         private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
         private readonly RefreshTokenService _sut;
         private readonly AccountEntity _account = CreateAccount();
-        private readonly RefreshTokenRequest _request = new(RefreshToken);
 
         public RotateAsync가_NotFound를_반환할_때()
         {
-            _refreshTokenRepository.FindIdByTokenAsync(RefreshToken).Returns(AccountId);
-            _accountRepository.FindByIdAsync(AccountId).Returns(_account);
+            _accountRepository.FindByIdAsync(_account.Id).Returns(_account);
             _refreshTokenRepository
-                .RotateAsync(_account.Id, RefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
+                .RotateAsync(_account.Id, ValidRefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
                 .Returns(RotateResult.NotFound);
             _jwtProvider.GenerateAccessToken(_account).Returns("new-access-token");
-            _jwtProvider.GenerateRefreshToken().Returns("new-refresh-token");
+            _jwtProvider.GenerateRefreshToken(Arg.Any<long>()).Returns("new-refresh-token");
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
             _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }
@@ -141,7 +145,7 @@ public class RefreshTokenServiceTests
         [Fact]
         public async Task 토큰_갱신_요청_시_UnauthorizedException이_발생한다()
         {
-            var act = async () => await _sut.ExecuteAsync(_request);
+            var act = async () => await _sut.ExecuteAsync(new RefreshTokenRequest(ValidRefreshToken));
 
             await act.Should().ThrowAsync<UnauthorizedException>()
                 .WithMessage("리프레시 토큰을 찾을 수 없습니다.");
@@ -156,17 +160,15 @@ public class RefreshTokenServiceTests
         private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
         private readonly RefreshTokenService _sut;
         private readonly AccountEntity _account = CreateAccount();
-        private readonly RefreshTokenRequest _request = new(RefreshToken);
 
         public RotateAsync가_Reused를_반환할_때()
         {
-            _refreshTokenRepository.FindIdByTokenAsync(RefreshToken).Returns(AccountId);
-            _accountRepository.FindByIdAsync(AccountId).Returns(_account);
+            _accountRepository.FindByIdAsync(_account.Id).Returns(_account);
             _refreshTokenRepository
-                .RotateAsync(_account.Id, RefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
+                .RotateAsync(_account.Id, ValidRefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
                 .Returns(RotateResult.Reused);
             _jwtProvider.GenerateAccessToken(_account).Returns("new-access-token");
-            _jwtProvider.GenerateRefreshToken().Returns("new-refresh-token");
+            _jwtProvider.GenerateRefreshToken(Arg.Any<long>()).Returns("new-refresh-token");
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
             _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }
@@ -174,7 +176,7 @@ public class RefreshTokenServiceTests
         [Fact]
         public async Task 토큰_갱신_요청_시_UnauthorizedException이_발생한다()
         {
-            var act = async () => await _sut.ExecuteAsync(_request);
+            var act = async () => await _sut.ExecuteAsync(new RefreshTokenRequest(ValidRefreshToken));
 
             await act.Should().ThrowAsync<UnauthorizedException>()
                 .WithMessage("토큰 재사용이 감지되었습니다.");

--- a/Fantasy-server/Fantasy.Test/Auth/Service/RefreshTokenServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Auth/Service/RefreshTokenServiceTests.cs
@@ -1,8 +1,8 @@
+using Fantasy.Server.Domain.Account.Repository.Interface;
 using Fantasy.Server.Domain.Auth.Dto.Request;
 using Fantasy.Server.Domain.Auth.Repository.Interface;
 using Fantasy.Server.Domain.Auth.Service;
 using Fantasy.Server.Global.Security.Jwt;
-using Fantasy.Server.Global.Security.Provider;
 using FluentAssertions;
 using Gamism.SDK.Extensions.AspNetCore.Exceptions;
 using Microsoft.Extensions.Configuration;
@@ -14,116 +14,134 @@ namespace Fantasy.Test.Auth.Service;
 
 public class RefreshTokenServiceTests
 {
+    private const string RefreshToken = "valid-refresh-token";
+    private const long AccountId = 1L;
+
+    private static AccountEntity CreateAccount()
+        => AccountEntity.Create("user@example.com", "hashed_password");
+
     public class 유효한_리프레시_토큰으로_요청할_때
     {
-        private readonly ICurrentUserProvider _currentUserProvider = Substitute.For<ICurrentUserProvider>();
+        private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
         private readonly IRefreshTokenRedisRepository _refreshTokenRepository = Substitute.For<IRefreshTokenRedisRepository>();
         private readonly IJwtProvider _jwtProvider = Substitute.For<IJwtProvider>();
         private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
         private readonly RefreshTokenService _sut;
-        private readonly AccountEntity _account = AccountEntity.Create("user@example.com", "hashed_password");
-        private readonly RefreshTokenRequest _request = new("valid-refresh-token");
+        private readonly AccountEntity _account = CreateAccount();
+        private readonly RefreshTokenRequest _request = new(RefreshToken);
 
         public 유효한_리프레시_토큰으로_요청할_때()
         {
-            _currentUserProvider.GetAccountAsync().Returns(_account);
-            _refreshTokenRepository.FindByIdAsync(_account.Id).Returns("valid-refresh-token");
+            _refreshTokenRepository.FindIdByTokenAsync(RefreshToken).Returns(AccountId);
+            _accountRepository.FindByIdAsync(AccountId).Returns(_account);
+            _refreshTokenRepository
+                .RotateAsync(_account.Id, RefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
+                .Returns(true);
             _jwtProvider.GenerateAccessToken(_account).Returns("new-access-token");
             _jwtProvider.GenerateRefreshToken().Returns("new-refresh-token");
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
-            _sut = new RefreshTokenService(_currentUserProvider, _refreshTokenRepository, _jwtProvider, _configuration);
+            _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }
 
         [Fact]
         public async Task 토큰_갱신_요청_시_새_AccessToken과_RefreshToken을_반환한다()
         {
-            // Arrange
-            // (생성자에서 설정 완료)
-
-            // Act
             var result = await _sut.ExecuteAsync(_request);
 
-            // Assert
             result.AccessToken.Should().Be("new-access-token");
             result.RefreshToken.Should().Be("new-refresh-token");
             result.AccessTokenExpiresAt.Should().BeGreaterThan(0);
         }
 
         [Fact]
-        public async Task 토큰_갱신_요청_시_새_리프레시_토큰이_Redis에_저장된다()
+        public async Task 토큰_갱신_요청_시_RotateAsync가_호출된다()
         {
-            // Arrange
-            // (생성자에서 설정 완료)
-
-            // Act
             await _sut.ExecuteAsync(_request);
 
-            // Assert
             await _refreshTokenRepository.Received(1)
-                .SaveAsync(_account.Id, "new-refresh-token", TimeSpan.FromDays(30));
+                .RotateAsync(_account.Id, RefreshToken, "new-refresh-token", TimeSpan.FromDays(30));
         }
     }
 
     public class Redis에_리프레시_토큰이_없을_때
     {
-        private readonly ICurrentUserProvider _currentUserProvider = Substitute.For<ICurrentUserProvider>();
+        private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
         private readonly IRefreshTokenRedisRepository _refreshTokenRepository = Substitute.For<IRefreshTokenRedisRepository>();
         private readonly IJwtProvider _jwtProvider = Substitute.For<IJwtProvider>();
         private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
         private readonly RefreshTokenService _sut;
-        private readonly AccountEntity _account = AccountEntity.Create("user@example.com", "hashed_password");
-        private readonly RefreshTokenRequest _request = new("some-refresh-token");
+        private readonly RefreshTokenRequest _request = new("unknown-token");
 
         public Redis에_리프레시_토큰이_없을_때()
         {
-            _currentUserProvider.GetAccountAsync().Returns(_account);
-            _refreshTokenRepository.FindByIdAsync(_account.Id).Returns((string?)null);
+            _refreshTokenRepository.FindIdByTokenAsync("unknown-token").Returns((long?)null);
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
-            _sut = new RefreshTokenService(_currentUserProvider, _refreshTokenRepository, _jwtProvider, _configuration);
+            _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }
 
         [Fact]
         public async Task 토큰_갱신_요청_시_UnauthorizedException이_발생한다()
         {
-            // Arrange
-            // (생성자에서 설정 완료)
-
-            // Act
             var act = async () => await _sut.ExecuteAsync(_request);
 
-            // Assert
             await act.Should().ThrowAsync<UnauthorizedException>();
         }
     }
 
-    public class 리프레시_토큰이_불일치할_때
+    public class 계정이_존재하지_않을_때
     {
-        private readonly ICurrentUserProvider _currentUserProvider = Substitute.For<ICurrentUserProvider>();
+        private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
         private readonly IRefreshTokenRedisRepository _refreshTokenRepository = Substitute.For<IRefreshTokenRedisRepository>();
         private readonly IJwtProvider _jwtProvider = Substitute.For<IJwtProvider>();
         private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
         private readonly RefreshTokenService _sut;
-        private readonly AccountEntity _account = AccountEntity.Create("user@example.com", "hashed_password");
-        private readonly RefreshTokenRequest _request = new("wrong-refresh-token");
+        private readonly RefreshTokenRequest _request = new(RefreshToken);
 
-        public 리프레시_토큰이_불일치할_때()
+        public 계정이_존재하지_않을_때()
         {
-            _currentUserProvider.GetAccountAsync().Returns(_account);
-            _refreshTokenRepository.FindByIdAsync(_account.Id).Returns("stored-refresh-token");
+            _refreshTokenRepository.FindIdByTokenAsync(RefreshToken).Returns(AccountId);
+            _accountRepository.FindByIdAsync(AccountId).Returns((AccountEntity?)null);
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
-            _sut = new RefreshTokenService(_currentUserProvider, _refreshTokenRepository, _jwtProvider, _configuration);
+            _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }
 
         [Fact]
         public async Task 토큰_갱신_요청_시_UnauthorizedException이_발생한다()
         {
-            // Arrange
-            // (생성자에서 설정 완료)
-
-            // Act
             var act = async () => await _sut.ExecuteAsync(_request);
 
-            // Assert
+            await act.Should().ThrowAsync<UnauthorizedException>();
+        }
+    }
+
+    public class RotateAsync가_실패할_때
+    {
+        private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
+        private readonly IRefreshTokenRedisRepository _refreshTokenRepository = Substitute.For<IRefreshTokenRedisRepository>();
+        private readonly IJwtProvider _jwtProvider = Substitute.For<IJwtProvider>();
+        private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
+        private readonly RefreshTokenService _sut;
+        private readonly AccountEntity _account = CreateAccount();
+        private readonly RefreshTokenRequest _request = new(RefreshToken);
+
+        public RotateAsync가_실패할_때()
+        {
+            _refreshTokenRepository.FindIdByTokenAsync(RefreshToken).Returns(AccountId);
+            _accountRepository.FindByIdAsync(AccountId).Returns(_account);
+            _refreshTokenRepository
+                .RotateAsync(_account.Id, RefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
+                .Returns(false);
+            _jwtProvider.GenerateAccessToken(_account).Returns("new-access-token");
+            _jwtProvider.GenerateRefreshToken().Returns("new-refresh-token");
+            _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
+            _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
+        }
+
+        [Fact]
+        public async Task 토큰_갱신_요청_시_UnauthorizedException이_발생한다()
+        {
+            var act = async () => await _sut.ExecuteAsync(_request);
+
             await act.Should().ThrowAsync<UnauthorizedException>();
         }
     }

--- a/Fantasy-server/Fantasy.Test/Auth/Service/RefreshTokenServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Auth/Service/RefreshTokenServiceTests.cs
@@ -106,6 +106,9 @@ public class RefreshTokenServiceTests
 
         public 계정이_존재하지_않을_때()
         {
+            _refreshTokenRepository
+                .RotateAsync(Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(), TimeSpan.FromDays(30))
+                .Returns(RotateResult.Success);
             _accountRepository.FindByIdAsync(Arg.Any<long>()).Returns((AccountEntity?)null);
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
             _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
@@ -128,16 +131,12 @@ public class RefreshTokenServiceTests
         private readonly IJwtProvider _jwtProvider = Substitute.For<IJwtProvider>();
         private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
         private readonly RefreshTokenService _sut;
-        private readonly AccountEntity _account = CreateAccount();
 
         public RotateAsync가_NotFound를_반환할_때()
         {
-            _accountRepository.FindByIdAsync(_account.Id).Returns(_account);
             _refreshTokenRepository
-                .RotateAsync(_account.Id, ValidRefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
+                .RotateAsync(Arg.Any<long>(), ValidRefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
                 .Returns(RotateResult.NotFound);
-            _jwtProvider.GenerateAccessToken(_account).Returns("new-access-token");
-            _jwtProvider.GenerateRefreshToken(Arg.Any<long>()).Returns("new-refresh-token");
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
             _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }
@@ -159,16 +158,12 @@ public class RefreshTokenServiceTests
         private readonly IJwtProvider _jwtProvider = Substitute.For<IJwtProvider>();
         private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
         private readonly RefreshTokenService _sut;
-        private readonly AccountEntity _account = CreateAccount();
 
         public RotateAsync가_Reused를_반환할_때()
         {
-            _accountRepository.FindByIdAsync(_account.Id).Returns(_account);
             _refreshTokenRepository
-                .RotateAsync(_account.Id, ValidRefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
+                .RotateAsync(Arg.Any<long>(), ValidRefreshToken, Arg.Any<string>(), TimeSpan.FromDays(30))
                 .Returns(RotateResult.Reused);
-            _jwtProvider.GenerateAccessToken(_account).Returns("new-access-token");
-            _jwtProvider.GenerateRefreshToken(Arg.Any<long>()).Returns("new-refresh-token");
             _configuration["Jwt:AccessTokenExpirationMinutes"].Returns("15");
             _sut = new RefreshTokenService(_accountRepository, _refreshTokenRepository, _jwtProvider, _configuration);
         }


### PR DESCRIPTION
## 📚작업 내용

- `RotateResult` 열거형 도입 (`NotFound`, `Reused`, `Success`)으로 토큰 로테이션 결과를 타입 안전하게 표현
- `RefreshTokenRedisRepository`에 Lua 스크립트 기반 원자적 로테이션(`RotateAsync`) 구현 — 토큰 불일치 시 forward/reverse 키 동시 삭제로 재사용 공격 방어
- `RefreshTokenService`에서 `RotateResult`를 기반으로 `NotFound` → `UnauthorizedException`, `Reused` → 토큰 도용 감지 후 전체 세션 무효화 처리
- `IRefreshTokenRedisRepository`에 `RotateAsync` 메서드 추가 및 관련 인터페이스 확장
- `RefreshTokenServiceTests`를 `RotateResult` 기반으로 전면 업데이트 (재사용 감지, 성공, 미존재 시나리오 포함)
- 예외 메시지 한국어로 통일

## ◀️참고 사항

Lua 스크립트 내에서 forward 키(계정ID → 토큰)와 reverse 키(토큰 → 계정ID)를 원자적으로 교체하므로 Redis 레벨에서 경쟁 조건이 발생하지 않습니다. 토큰 재사용이 감지된 경우(`Reused`) 두 키를 즉시 삭제하여 탈취된 세션을 무효화합니다.

## ✅체크리스트

> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.

- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?


> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*
