### PR TITLE
test: 골드 던전 테스트 예외 검증 방식 정리

### DIFF
--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonServiceTests.cs
@@ -96,8 +96,9 @@ public class GoldDungeonServiceTests
         {
             var request = new GoldDungeonRequest(Clicks: 1000, DurationSeconds: 30);
 
-            try { await _sut.ExecuteAsync(JobType.Warrior, request); } catch { }
+            var act = async () => await _sut.ExecuteAsync(JobType.Warrior, request);
 
+            await act.Should().ThrowAsync<BadRequestException>();
             await _playerResourceRepository.DidNotReceive().UpdateAsync(Arg.Any<PlayerResource>());
         }
     }

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonServiceTests.cs
@@ -96,7 +96,7 @@ public class GoldDungeonServiceTests
         {
             var request = new GoldDungeonRequest(Clicks: 1000, DurationSeconds: 30);
 
-            var act = async () => await _sut.ExecuteAsync(JobType.Warrior, request);
+            var act = () => _sut.ExecuteAsync(JobType.Warrior, request);
 
             await act.Should().ThrowAsync<BadRequestException>();
             await _playerResourceRepository.DidNotReceive().UpdateAsync(Arg.Any<PlayerResource>());


### PR DESCRIPTION
## 작업 내용

- 골드 던전 테스트에서 빈 `catch` 블록을 제거했습니다
- `BadRequestException` 발생을 FluentAssertions 방식으로 명확하게 검증하도록 수정했습니다

## 추가 참고사항

테스트 의도를 더 분명하게 드러내고, 예외를 조용히 삼키지 않도록 정리한 변경입니다.

## 체크리스트

> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.

- [x] 현재 하려고 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능에 영향을 끼치지 않나요?
