### PR TITLE
chore: 배포 워크플로와 운영 설정 정리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,17 +58,24 @@ jobs:
               "${{ secrets.REDIS_CONNECTION_STRING }}" \
               "${{ secrets.JWT_SECRET_KEY }}" \
               > ~/deploy/.env
+            chmod 600 ~/deploy/.env
 
             docker compose -f ~/deploy/compose.prod.yaml --env-file ~/deploy/.env pull
             docker compose -f ~/deploy/compose.prod.yaml --env-file ~/deploy/.env up -d --remove-orphans
 
-            sleep 5
-
-            if ! docker ps | grep -q fantasy-server; then
-              echo "::error::컨테이너 실행 실패 — 로그 확인"
-              docker logs fantasy-server --tail 50
-              exit 1
-            fi
+            for i in $(seq 1 12); do
+              if curl -sf http://localhost/v1/health > /dev/null 2>&1; then
+                echo "서버 정상 기동 확인"
+                break
+              fi
+              if [ "$i" -eq 12 ]; then
+                echo "::error::컨테이너 기동 실패 — 로그 확인"
+                docker logs fantasy-server --tail 50
+                exit 1
+              fi
+              echo "헬스체크 대기 중... ($i/12)"
+              sleep 5
+            done
 
             docker logs fantasy-server --tail 20
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: Deploy fantasy-server
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -t ${{ secrets.DOCKER_USERNAME }}/fantasy-server:latest \
+            -t ${{ secrets.DOCKER_USERNAME }}/fantasy-server:${{ github.sha }} \
+            -f Fantasy-server/Fantasy.Server/deploy/prod.dockerfile \
+            Fantasy-server
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ secrets.DOCKER_USERNAME }}/fantasy-server:latest
+          docker push ${{ secrets.DOCKER_USERNAME }}/fantasy-server:${{ github.sha }}
+
+      - name: Copy compose file to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          port: ${{ secrets.SSH_PORT }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "Fantasy-server/Fantasy.Server/deploy/compose.prod.yaml"
+          target: "~/deploy/"
+          strip_components: 3
+
+      - name: Deploy via Docker Compose
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          port: ${{ secrets.SSH_PORT }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            mkdir -p ~/deploy
+
+            printf 'DOCKER_USERNAME=%s\nPOSTGRES_USER=%s\nPOSTGRES_PASSWORD=%s\nDB_CONNECTION_STRING=%s\nREDIS_CONNECTION_STRING=%s\nJWT_SECRET_KEY=%s\n' \
+              "${{ secrets.DOCKER_USERNAME }}" \
+              "${{ secrets.POSTGRES_USER }}" \
+              "${{ secrets.POSTGRES_PASSWORD }}" \
+              "${{ secrets.DB_CONNECTION_STRING }}" \
+              "${{ secrets.REDIS_CONNECTION_STRING }}" \
+              "${{ secrets.JWT_SECRET_KEY }}" \
+              > ~/deploy/.env
+
+            docker compose -f ~/deploy/compose.prod.yaml --env-file ~/deploy/.env pull
+            docker compose -f ~/deploy/compose.prod.yaml --env-file ~/deploy/.env up -d --remove-orphans
+
+            sleep 5
+
+            if ! docker ps | grep -q fantasy-server; then
+              echo "::error::컨테이너 실행 실패 — 로그 확인"
+              docker logs fantasy-server --tail 50
+              exit 1
+            fi
+
+            docker logs fantasy-server --tail 20
+
+            docker image prune -f

--- a/Fantasy-server/.agents/skills/commit/SKILL.md
+++ b/Fantasy-server/.agents/skills/commit/SKILL.md
@@ -60,11 +60,13 @@ See `.claude/skills/commit/examples/type-guide.md` for a boundary-rule table and
 
 Always check the current branch before staging or committing.
 
+- When creating a branch from `develop`, always use the format `{type}/{content}`
+- Do not use `{type}-{content}` or omit the slash between type and content
 - If the current branch is **not** `develop`, proceed with the normal commit flow.
 - If the current branch **is** `develop`:
   - Review the changes first with `git status` and `git diff`
   - Infer the dominant logical unit and create a new working branch before any `git add` or `git commit`
-  - Use a short branch name based on the work, such as `feat/player-resource-seed`, `fix/player-stage-config`, or `update/player-domain-cleanup`
+  - Use a short branch name based on the work, such as `feat/player-resource-seed`, `fix/player-stage-config`, `update/player-domain-cleanup`, or `chore/deploy-pipeline`
   - Run `git switch -c <branch-name>`
   - Confirm the branch changed successfully, then continue the commit flow on that new branch
 

--- a/Fantasy-server/.agents/skills/plan-deep-dive/SKILL.md
+++ b/Fantasy-server/.agents/skills/plan-deep-dive/SKILL.md
@@ -1,8 +1,23 @@
-﻿---
+---
 name: plan-deep-dive
 description: Conduct an in-depth structured interview with the user to uncover non-obvious requirements, tradeoffs, and constraints, then produce a detailed implementation spec file.
 argument-hint: [instructions]
-allowed-tools: AskUserQuestion, Write
+allowed-tools: Read, Write
+context: fork
 ---
 
-Follow the user instructions and interview me in detail using the AskUserQuestionTool about literally anything: technical implementation, UI & UX, concerns, tradeoffs, etc. but make sure the questions are not obvious. be very in-depth and continue interviewing me continually until it's complete. then, write the spec to a file. <instructions>$ARGUMENTS</instructions>
+Follow the user instructions and conduct a structured, in-depth interview to uncover non-obvious requirements, constraints, and tradeoffs before writing an implementation spec.
+
+Use the conversation to ask targeted questions about:
+
+- technical scope and constraints
+- product and UX expectations
+- edge cases and failure handling
+- rollout, migration, and operational risks
+- testing and validation expectations
+
+Avoid obvious or redundant questions. Keep drilling down until the requirements are concrete enough to implement safely.
+
+After the interview is complete, write the resulting spec to a file and summarize the key decisions and open questions.
+
+<instructions>$ARGUMENTS</instructions>

--- a/Fantasy-server/.claude/skills/commit/SKILL.md
+++ b/Fantasy-server/.claude/skills/commit/SKILL.md
@@ -60,11 +60,13 @@ See `.claude/skills/commit/examples/type-guide.md` for a boundary-rule table and
 
 Always check the current branch before staging or committing.
 
+- When creating a branch from `develop`, always use the format `{type}/{content}`
+- Do not use `{type}-{content}` or omit the slash between type and content
 - If the current branch is **not** `develop`, proceed with the normal commit flow.
 - If the current branch **is** `develop`:
   - Review the changes first with `git status` and `git diff`
   - Infer the dominant logical unit and create a new working branch before any `git add` or `git commit`
-  - Use a short branch name based on the work, such as `feat/player-resource-seed`, `fix/player-stage-config`, or `update/player-domain-cleanup`
+  - Use a short branch name based on the work, such as `feat/player-resource-seed`, `fix/player-stage-config`, `update/player-domain-cleanup`, or `chore/deploy-pipeline`
   - Run `git switch -c <branch-name>`
   - Confirm the branch changed successfully, then continue the commit flow on that new branch
 

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/BasicDungeonClaimService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/BasicDungeonClaimService.cs
@@ -112,7 +112,7 @@ public class BasicDungeonClaimService : IBasicDungeonClaimService
         var (earnedGold, earnedXp, newMaxStage) = SimulateDungeon(
             dps, combatStat.Hp, elapsedSeconds, stage.MaxStage, stageData);
 
-        var levelUps = await _levelUpService.ApplyExpAsync(player, resource, earnedXp);
+        var levelUps = await _levelUpService.ExecuteAsync(player, resource, earnedXp);
         resource.UpdateGold(resource.Gold + earnedGold);
         stage.Update(newMaxStage);
         stage.UpdateLastCalculatedAt();

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/BossDungeonService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/BossDungeonService.cs
@@ -112,7 +112,7 @@ public class BossDungeonService : IBossDungeonService
             return new BossDungeonResponse(false, 0, null, 0, []);
 
         var earnedXp = stageData.XpPerSecond * BossXpMultiplier;
-        var levelUps = await _levelUpService.ApplyExpAsync(player, resource, earnedXp);
+        var levelUps = await _levelUpService.ExecuteAsync(player, resource, earnedXp);
         resource.UpdateChangeData(null, resource.Mithril + BossMithrilReward, null);
 
         DroppedWeaponInfo? droppedWeapon = null;

--- a/Fantasy-server/Fantasy.Server/Domain/LevelUp/Service/Interface/ILevelUpService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/LevelUp/Service/Interface/ILevelUpService.cs
@@ -6,5 +6,5 @@ namespace Fantasy.Server.Domain.LevelUp.Service.Interface;
 
 public interface ILevelUpService
 {
-    Task<List<LevelUpResult>> ApplyExpAsync(PlayerEntity player, PlayerResource resource, long earnedExp);
+    Task<List<LevelUpResult>> ExecuteAsync(PlayerEntity player, PlayerResource resource, long earnedExp);
 }

--- a/Fantasy-server/Fantasy.Server/Domain/LevelUp/Service/LevelUpService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/LevelUp/Service/LevelUpService.cs
@@ -17,7 +17,7 @@ public class LevelUpService : ILevelUpService
         _gameDataCacheService = gameDataCacheService;
     }
 
-    public async Task<List<LevelUpResult>> ApplyExpAsync(PlayerEntity player, PlayerResource resource, long earnedExp)
+    public async Task<List<LevelUpResult>> ExecuteAsync(PlayerEntity player, PlayerResource resource, long earnedExp)
     {
         var levelTable = await _gameDataCacheService.GetLevelTableAsync();
         var levelUps = new List<LevelUpResult>();

--- a/Fantasy-server/Fantasy.Server/deploy/compose.dev.yaml
+++ b/Fantasy-server/Fantasy.Server/deploy/compose.dev.yaml
@@ -27,7 +27,7 @@ services:
       - ConnectionStrings__Database=Host=fantasy-db;Port=5432;Database=fantasy;Username=fantasy;Password=fantasy
       - ConnectionStrings__Redis=fantasy-redis:6379
     volumes:
-      - .:/src
+      - ../../:/src
     depends_on:
       - fantasy-db
       - fantasy-redis

--- a/Fantasy-server/Fantasy.Server/deploy/compose.prod.yaml
+++ b/Fantasy-server/Fantasy.Server/deploy/compose.prod.yaml
@@ -18,10 +18,10 @@ services:
     restart: unless-stopped
 
   fantasy-server:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/fantasy-server:latest
+    image: ${DOCKER_USERNAME}/fantasy-server:latest
     container_name: fantasy-server
     ports:
-      - "8080:8080"
+      - "80:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ConnectionStrings__Database=${DB_CONNECTION_STRING}

--- a/Fantasy-server/Fantasy.Server/deploy/compose.prod.yaml
+++ b/Fantasy-server/Fantasy.Server/deploy/compose.prod.yaml
@@ -31,6 +31,12 @@ services:
       - fantasy-db
       - fantasy-redis
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/v1/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
 
 volumes:
   postgres_data:

--- a/Fantasy-server/Fantasy.Server/deploy/prod.dockerfile
+++ b/Fantasy-server/Fantasy.Server/deploy/prod.dockerfile
@@ -1,11 +1,19 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
+COPY Fantasy-server.sln .
+COPY Fantasy.Server/Fantasy.Server.csproj Fantasy.Server/
+COPY Fantasy.Test/Fantasy.Test.csproj Fantasy.Test/
+RUN dotnet restore Fantasy.Server/Fantasy.Server.csproj
 COPY . .
 RUN dotnet publish Fantasy.Server/Fantasy.Server.csproj \
     --configuration Release \
+    --no-restore \
     --output /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /app/publish .
 ENTRYPOINT ["dotnet", "Fantasy.Server.dll"]

--- a/Fantasy-server/Fantasy.Server/deploy/prod.dockerfile
+++ b/Fantasy-server/Fantasy.Server/deploy/prod.dockerfile
@@ -3,7 +3,7 @@ WORKDIR /src
 COPY Fantasy-server.sln .
 COPY Fantasy.Server/Fantasy.Server.csproj Fantasy.Server/
 COPY Fantasy.Test/Fantasy.Test.csproj Fantasy.Test/
-RUN dotnet restore Fantasy.Server/Fantasy.Server.csproj
+RUN dotnet restore Fantasy-server.sln
 COPY . .
 RUN dotnet publish Fantasy.Server/Fantasy.Server.csproj \
     --configuration Release \

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/BasicDungeonClaimServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/BasicDungeonClaimServiceTests.cs
@@ -150,7 +150,7 @@ public class BasicDungeonClaimServiceTests
             _gameDataCacheService.GetJobBaseStatAsync(JobType.Warrior)
                 .Returns(JobBaseStat.Create(JobType.Warrior, 1000, 200, 0.1, 1.5, 50, 10));
             _gameDataCacheService.GetSkillDataByJobAsync(Arg.Any<JobType>()).Returns([]);
-            _levelUpService.ApplyExpAsync(Arg.Any<PlayerEntity>(), Arg.Any<PlayerResource>(), Arg.Any<long>())
+            _levelUpService.ExecuteAsync(Arg.Any<PlayerEntity>(), Arg.Any<PlayerResource>(), Arg.Any<long>())
                 .Returns([]);
             _transactionRunner.ExecuteAsync(Arg.Any<Func<Task>>())
                 .Returns(callInfo => callInfo.Arg<Func<Task>>()());

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/BossDungeonServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/BossDungeonServiceTests.cs
@@ -179,7 +179,7 @@ public class BossDungeonServiceTests
             _gameDataCacheService.GetSkillDataByJobAsync(Arg.Any<JobType>()).Returns([]);
             _gameDataCacheService.GetWeaponDataByGradeAsync(WeaponGrade.A)
                 .Returns([WeaponData.Create(10, "A등급검", WeaponGrade.A, JobType.Warrior, 500, 20)]);
-            _levelUpService.ApplyExpAsync(Arg.Any<PlayerEntity>(), Arg.Any<PlayerResource>(), Arg.Any<long>())
+            _levelUpService.ExecuteAsync(Arg.Any<PlayerEntity>(), Arg.Any<PlayerResource>(), Arg.Any<long>())
                 .Returns([]);
             _transactionRunner.ExecuteAsync(Arg.Any<Func<Task>>())
                 .Returns(callInfo => callInfo.Arg<Func<Task>>()());
@@ -285,7 +285,7 @@ public class BossDungeonServiceTests
                 .Returns(JobBaseStat.Create(JobType.Warrior, 1000, 100, 0, 1.5, 10, 10));
             _gameDataCacheService.GetSkillDataByJobAsync(Arg.Any<JobType>()).Returns([]);
             _gameDataCacheService.GetWeaponDataByGradeAsync(WeaponGrade.A).Returns([]);
-            _levelUpService.ApplyExpAsync(Arg.Any<PlayerEntity>(), Arg.Any<PlayerResource>(), Arg.Any<long>())
+            _levelUpService.ExecuteAsync(Arg.Any<PlayerEntity>(), Arg.Any<PlayerResource>(), Arg.Any<long>())
                 .Returns([]);
             _transactionRunner.ExecuteAsync(Arg.Any<Func<Task>>())
                 .Returns(callInfo => callInfo.Arg<Func<Task>>()());

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonServiceTests.cs
@@ -96,8 +96,9 @@ public class GoldDungeonServiceTests
         {
             var request = new GoldDungeonRequest(Clicks: 1000, DurationSeconds: 30);
 
-            try { await _sut.ExecuteAsync(JobType.Warrior, request); } catch { }
+            var act = async () => await _sut.ExecuteAsync(JobType.Warrior, request);
 
+            await act.Should().ThrowAsync<BadRequestException>();
             await _playerResourceRepository.DidNotReceive().UpdateAsync(Arg.Any<PlayerResource>());
         }
     }

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonServiceTests.cs
@@ -96,7 +96,7 @@ public class GoldDungeonServiceTests
         {
             var request = new GoldDungeonRequest(Clicks: 1000, DurationSeconds: 30);
 
-            var act = async () => await _sut.ExecuteAsync(JobType.Warrior, request);
+            var act = () => _sut.ExecuteAsync(JobType.Warrior, request);
 
             await act.Should().ThrowAsync<BadRequestException>();
             await _playerResourceRepository.DidNotReceive().UpdateAsync(Arg.Any<PlayerResource>());

--- a/Fantasy-server/Fantasy.Test/LevelUp/Service/LevelUpServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/LevelUp/Service/LevelUpServiceTests.cs
@@ -46,7 +46,7 @@ public class LevelUpServiceTests
             var player = MakePlayer(level: 1, exp: 0);
             var resource = MakeResource();
 
-            var result = await _sut.ApplyExpAsync(player, resource, earnedExp: 50);
+            var result = await _sut.ExecuteAsync(player, resource, earnedExp: 50);
 
             result.Should().BeEmpty();
             player.Level.Should().Be(1);
@@ -58,7 +58,7 @@ public class LevelUpServiceTests
             var player = MakePlayer(level: 1, exp: 0);
             var resource = MakeResource();
 
-            await _sut.ApplyExpAsync(player, resource, earnedExp: 50);
+            await _sut.ExecuteAsync(player, resource, earnedExp: 50);
 
             player.Exp.Should().Be(50);
         }
@@ -81,7 +81,7 @@ public class LevelUpServiceTests
             var player = MakePlayer(level: 1, exp: 0);
             var resource = MakeResource();
 
-            await _sut.ApplyExpAsync(player, resource, earnedExp: 100);
+            await _sut.ExecuteAsync(player, resource, earnedExp: 100);
 
             player.Level.Should().Be(2);
         }
@@ -92,7 +92,7 @@ public class LevelUpServiceTests
             var player = MakePlayer(level: 1, exp: 0);
             var resource = MakeResource();
 
-            var result = await _sut.ApplyExpAsync(player, resource, earnedExp: 100);
+            var result = await _sut.ExecuteAsync(player, resource, earnedExp: 100);
 
             result.Should().HaveCount(1);
             result[0].NewLevel.Should().Be(2);
@@ -105,7 +105,7 @@ public class LevelUpServiceTests
             var player = MakePlayer(level: 1, exp: 0);
             var resource = MakeResource();
 
-            await _sut.ApplyExpAsync(player, resource, earnedExp: 100);
+            await _sut.ExecuteAsync(player, resource, earnedExp: 100);
 
             resource.Sp.Should().Be(3);
         }
@@ -116,7 +116,7 @@ public class LevelUpServiceTests
             var player = MakePlayer(level: 1, exp: 0);
             var resource = MakeResource();
 
-            await _sut.ApplyExpAsync(player, resource, earnedExp: 100);
+            await _sut.ExecuteAsync(player, resource, earnedExp: 100);
 
             player.Exp.Should().Be(0);
         }
@@ -140,7 +140,7 @@ public class LevelUpServiceTests
             var resource = MakeResource();
 
             // 레벨1 → 2 (100 XP), 레벨2 → 3 (200 XP) = 300 XP
-            await _sut.ApplyExpAsync(player, resource, earnedExp: 300);
+            await _sut.ExecuteAsync(player, resource, earnedExp: 300);
 
             player.Level.Should().Be(3);
         }
@@ -151,7 +151,7 @@ public class LevelUpServiceTests
             var player = MakePlayer(level: 1, exp: 0);
             var resource = MakeResource();
 
-            var result = await _sut.ApplyExpAsync(player, resource, earnedExp: 300);
+            var result = await _sut.ExecuteAsync(player, resource, earnedExp: 300);
 
             result.Should().HaveCount(2);
             result[0].NewLevel.Should().Be(2);
@@ -165,7 +165,7 @@ public class LevelUpServiceTests
             var resource = MakeResource();
 
             // 100 (lv1→2) + 200 (lv2→3) + 50 남음
-            await _sut.ApplyExpAsync(player, resource, earnedExp: 350);
+            await _sut.ExecuteAsync(player, resource, earnedExp: 350);
 
             player.Exp.Should().Be(50);
         }
@@ -176,7 +176,7 @@ public class LevelUpServiceTests
             var player = MakePlayer(level: 1, exp: 0);
             var resource = MakeResource();
 
-            await _sut.ApplyExpAsync(player, resource, earnedExp: 300);
+            await _sut.ExecuteAsync(player, resource, earnedExp: 300);
 
             resource.Sp.Should().Be(3 + 5); // lv1 reward + lv2 reward
         }
@@ -200,7 +200,7 @@ public class LevelUpServiceTests
             var resource = MakeResource();
 
             // 80 + 30 = 110 >= 100 → 레벨업
-            var result = await _sut.ApplyExpAsync(player, resource, earnedExp: 30);
+            var result = await _sut.ExecuteAsync(player, resource, earnedExp: 30);
 
             result.Should().HaveCount(1);
             player.Level.Should().Be(2);


### PR DESCRIPTION
## 📚작업 내용

- GitHub 배포 워크플로에 `.env` 권한 설정과 헬스체크 대기 로직을 추가하고, 운영 컴포즈에 서버 헬스체크를 설정
- 운영 배포 이미지를 `DOCKER_USERNAME` 기반으로 통일하고, 운영 포트를 `80:8080`으로 조정
- 운영 Dockerfile에 사전 `restore` 단계와 `curl` 설치를 추가하고, 개발 컴포즈의 소스 마운트 경로를 저장소 루트 기준으로 수정
- 레벨업 서비스 메서드명을 `ExecuteAsync`로 정리하고 관련 던전 서비스 및 테스트 호출부를 일괄 반영
- 골드 던전 테스트의 예외 검증 방식을 `ThrowAsync` 기반으로 정리하고, 커밋/plan-deep-dive 스킬 문서를 최신 규칙에 맞게 보완

## ◀️참고 사항

이 브랜치에는 배포 파이프라인 정리와 함께 테스트 코드 및 로컬 스킬 문서 정리가 포함되어 있습니다.

## ✅체크리스트

> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.

- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?


> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*
