### PR TITLE
feat: 계정당 단일 플레이어 모델로 전환

### DIFF
--- a/Fantasy-server/.claude/rules/domain-patterns.md
+++ b/Fantasy-server/.claude/rules/domain-patterns.md
@@ -4,88 +4,30 @@ globs: ["Fantasy.Server/Domain/**"]
 alwaysApply: false
 ---
 
-## Service Pattern
+## Patterns
 
-Each use case is a single class implementing a single interface with one `ExecuteAsync` method.
+- **Service**: single interface + single `ExecuteAsync` method per use case.
+- **Repository**: interface in `Repository/Interface/`, impl in `Repository/`. Only repositories touch `AppDbContext`. Use `AsNoTracking()` for reads.
+- **Controller**: inject service interfaces only. Apply `[EnableRateLimiting("policy-name")]` where needed.
 
-```csharp
-// Interface
-public interface ICreateAccountService
-{
-    Task ExecuteAsync(CreateAccountRequest request);
-}
+## Gamism.SDK
 
-// Implementation
-public class CreateAccountService : ICreateAccountService
-{
-    private readonly IAccountRepository _accountRepository;
+Controllers can return DTOs directly — `ApiResponseWrapperFilter` auto-wraps them into `CommonApiResponse<T>`.
 
-    public CreateAccountService(IAccountRepository accountRepository)
-    {
-        _accountRepository = accountRepository;
-    }
+| Return | HTTP | Result |
+|---|---|---|
+| Plain object | 200 | `CommonApiResponse.Success("OK", value)` |
+| `void` / `null` | 204 | Empty |
+| `CommonApiResponse` | `code` value | Passed through as-is |
 
-    public async Task ExecuteAsync(CreateAccountRequest request)
-    {
-        if (await _accountRepository.ExistsByEmailAsync(request.Email))
-            throw new ConflictException("이미 사용중인 이메일입니다.");
-
-        var hashed = BCrypt.Net.BCrypt.HashPassword(request.Password);
-        var account = AccountEntity.Create(request.Email, hashed);
-        await _accountRepository.SaveAsync(account);
-    }
-}
-```
-
-## Repository Pattern
-
-- Interface in `Repository/Interface/`, implementation in `Repository/`.
-- Only repositories access `AppDbContext`.
-- Use `AsNoTracking()` for read-only queries.
+**Error handling — always `throw`, never `return`:**
 
 ```csharp
-public class AccountRepository : IAccountRepository
-{
-    private readonly AppDbContext _db;
+// ❌ breaks CommonApiResponse format
+return NotFound();
 
-    public AccountRepository(AppDbContext db) => _db = db;
-
-    public async Task<Account?> FindByEmailAsync(string email)
-        => await _db.Accounts.AsNoTracking().FirstOrDefaultAsync(a => a.Email == email);
-
-    public async Task<Account> SaveAsync(Account account)
-    {
-        if (_db.Accounts.Entry(account).State == EntityState.Detached)
-            await _db.Accounts.AddAsync(account);
-        await _db.SaveChangesAsync();
-        return account;
-    }
-}
+// ✅
+throw new NotFoundException("Player not found.");
 ```
 
-## Controller Pattern
-
-- Inject service interfaces only.
-- Return `CommonApiResponse` from `Gamism.SDK`.
-- Apply rate limiting via `[EnableRateLimiting("policy-name")]`.
-
-```csharp
-[ApiController]
-[Route("v1/account")]
-public class AccountController : ControllerBase
-{
-    private readonly ICreateAccountService _createAccountService;
-
-    public AccountController(ICreateAccountService createAccountService)
-    {
-        _createAccountService = createAccountService;
-    }
-
-    [HttpPost("signup")]
-    public async Task<CommonApiResponse> SignUp([FromBody] CreateAccountRequest request)
-    {
-        await _createAccountService.ExecuteAsync(request);
-        return CommonApiResponse.Created("계정이 생성되었습니다.");
-    }
-}
-```
+Exception classes: `BadRequestException` (400), `UnauthorizedException` (401), `ForbiddenException` (403), `NotFoundException` (404), `ConflictException` (409). Use `ExpectedException(HttpStatusCode, message)` for anything else.

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Controller/DungeonController.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Controller/DungeonController.cs
@@ -1,7 +1,6 @@
 using Fantasy.Server.Domain.Dungeon.Dto.Request;
 using Fantasy.Server.Domain.Dungeon.Dto.Response;
 using Fantasy.Server.Domain.Dungeon.Service.Interface;
-using Fantasy.Server.Domain.Player.Enum;
 using Gamism.SDK.Core.Network;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -33,32 +32,30 @@ public class DungeonController : ControllerBase
     }
 
     [HttpPost("basic/claim")]
-    public async Task<CommonApiResponse<BasicDungeonClaimResponse>> BasicClaim([FromQuery] JobType jobType)
+    public async Task<CommonApiResponse<BasicDungeonClaimResponse>> BasicClaim()
     {
-        var result = await _basicDungeonClaimService.ExecuteAsync(jobType);
+        var result = await _basicDungeonClaimService.ExecuteAsync();
         return CommonApiResponse.Success("기본 던전 정산이 완료되었습니다.", result);
     }
 
     [HttpPost("gold")]
-    public async Task<CommonApiResponse<GoldDungeonResponse>> Gold(
-        [FromQuery] JobType jobType,
-        [FromBody] GoldDungeonRequest request)
+    public async Task<CommonApiResponse<GoldDungeonResponse>> Gold([FromBody] GoldDungeonRequest request)
     {
-        var result = await _goldDungeonService.ExecuteAsync(jobType, request);
+        var result = await _goldDungeonService.ExecuteAsync(request);
         return CommonApiResponse.Success("골드 던전이 완료되었습니다.", result);
     }
 
     [HttpPost("weapon")]
-    public async Task<CommonApiResponse<WeaponDungeonResponse>> Weapon([FromQuery] JobType jobType)
+    public async Task<CommonApiResponse<WeaponDungeonResponse>> Weapon()
     {
-        var result = await _weaponDungeonService.ExecuteAsync(jobType);
+        var result = await _weaponDungeonService.ExecuteAsync();
         return CommonApiResponse.Success("무기 던전이 완료되었습니다.", result);
     }
 
     [HttpPost("boss")]
-    public async Task<CommonApiResponse<BossDungeonResponse>> Boss([FromQuery] JobType jobType)
+    public async Task<CommonApiResponse<BossDungeonResponse>> Boss()
     {
-        var result = await _bossDungeonService.ExecuteAsync(jobType);
+        var result = await _bossDungeonService.ExecuteAsync();
         return CommonApiResponse.Success("보스 던전이 완료되었습니다.", result);
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/BasicDungeonClaimService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/BasicDungeonClaimService.cs
@@ -3,8 +3,6 @@ using Fantasy.Server.Domain.Dungeon.Service.Interface;
 using Fantasy.Server.Domain.GameData.Entity;
 using Fantasy.Server.Domain.GameData.Service.Interface;
 using Fantasy.Server.Domain.LevelUp.Service.Interface;
-using Fantasy.Server.Domain.Player.Entity;
-using Fantasy.Server.Domain.Player.Enum;
 using Fantasy.Server.Domain.Player.Repository.Interface;
 using Fantasy.Server.Global.Infrastructure;
 using Fantasy.Server.Global.Security.Provider;
@@ -57,11 +55,11 @@ public class BasicDungeonClaimService : IBasicDungeonClaimService
         _calculator = calculator;
     }
 
-    public async Task<BasicDungeonClaimResponse> ExecuteAsync(JobType jobType)
+    public async Task<BasicDungeonClaimResponse> ExecuteAsync()
     {
         var accountId = _currentUserProvider.GetAccountId();
 
-        var player = await _playerRepository.FindByAccountAndJobAsync(accountId, jobType)
+        var player = await _playerRepository.FindByAccountAsync(accountId)
             ?? throw new NotFoundException("플레이어 데이터를 찾을 수 없습니다.");
 
         var resource = await _playerResourceRepository.FindByPlayerIdAsync(player.Id)
@@ -110,7 +108,7 @@ public class BasicDungeonClaimService : IBasicDungeonClaimService
         var dps = _calculator.CalculateDps(combatStat);
 
         var (earnedGold, earnedXp, newMaxStage) = SimulateDungeon(
-            dps, combatStat.Hp, elapsedSeconds, stage.MaxStage, stageData);
+            dps, elapsedSeconds, stage.MaxStage, stageData);
 
         var levelUps = await _levelUpService.ExecuteAsync(player, resource, earnedXp);
         resource.UpdateGold(resource.Gold + earnedGold);
@@ -124,13 +122,13 @@ public class BasicDungeonClaimService : IBasicDungeonClaimService
             await _playerStageRepository.UpdateAsync(stage);
         });
 
-        await _playerRedisRepository.DeleteAsync(accountId, jobType);
+        await _playerRedisRepository.DeleteAsync(accountId);
 
         return new BasicDungeonClaimResponse(earnedGold, earnedXp, newMaxStage, player.Level, levelUps);
     }
 
     private static (long Gold, long Xp, long NewMaxStage) SimulateDungeon(
-        double dps, long hp, long elapsedSeconds, long currentMaxStage, StageData stageData)
+        double dps, long elapsedSeconds, long currentMaxStage, StageData stageData)
     {
         long earnedGold = 0;
         long earnedXp = 0;

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/BossDungeonService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/BossDungeonService.cs
@@ -5,7 +5,6 @@ using Fantasy.Server.Domain.GameData.Enum;
 using Fantasy.Server.Domain.GameData.Service.Interface;
 using Fantasy.Server.Domain.LevelUp.Service.Interface;
 using Fantasy.Server.Domain.Player.Dto.Request;
-using Fantasy.Server.Domain.Player.Enum;
 using Fantasy.Server.Domain.Player.Repository.Interface;
 using Fantasy.Server.Global.Infrastructure;
 using Fantasy.Server.Global.Security.Provider;
@@ -59,12 +58,14 @@ public class BossDungeonService : IBossDungeonService
         _calculator = calculator;
     }
 
-    public async Task<BossDungeonResponse> ExecuteAsync(JobType jobType)
+    public async Task<BossDungeonResponse> ExecuteAsync()
     {
         var accountId = _currentUserProvider.GetAccountId();
 
-        var player = await _playerRepository.FindByAccountAndJobAsync(accountId, jobType)
+        var player = await _playerRepository.FindByAccountAsync(accountId)
             ?? throw new NotFoundException("플레이어 데이터를 찾을 수 없습니다.");
+
+        var jobType = player.JobType;
 
         var resource = await _playerResourceRepository.FindByPlayerIdAsync(player.Id)
             ?? throw new NotFoundException("플레이어 재화 데이터를 찾을 수 없습니다.");
@@ -138,7 +139,7 @@ public class BossDungeonService : IBossDungeonService
                 await _playerWeaponRepository.UpsertRangeAsync(player.Id, weaponChanges);
         });
 
-        await _playerRedisRepository.DeleteAsync(accountId, jobType);
+        await _playerRedisRepository.DeleteAsync(accountId);
 
         return new BossDungeonResponse(true, BossMithrilReward, droppedWeapon, earnedXp, levelUps);
     }

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/GoldDungeonService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/GoldDungeonService.cs
@@ -1,7 +1,6 @@
 using Fantasy.Server.Domain.Dungeon.Dto.Request;
 using Fantasy.Server.Domain.Dungeon.Dto.Response;
 using Fantasy.Server.Domain.Dungeon.Service.Interface;
-using Fantasy.Server.Domain.Player.Enum;
 using Fantasy.Server.Domain.Player.Repository.Interface;
 using Fantasy.Server.Global.Security.Provider;
 using Gamism.SDK.Extensions.AspNetCore.Exceptions;
@@ -31,14 +30,14 @@ public class GoldDungeonService : IGoldDungeonService
         _currentUserProvider = currentUserProvider;
     }
 
-    public async Task<GoldDungeonResponse> ExecuteAsync(JobType jobType, GoldDungeonRequest request)
+    public async Task<GoldDungeonResponse> ExecuteAsync(GoldDungeonRequest request)
     {
         if (request.Clicks > MaxClicksPerSecond * request.DurationSeconds)
             throw new BadRequestException("비정상적인 클릭 횟수입니다.");
 
         var accountId = _currentUserProvider.GetAccountId();
 
-        var player = await _playerRepository.FindByAccountAndJobAsync(accountId, jobType)
+        var player = await _playerRepository.FindByAccountAsync(accountId)
             ?? throw new NotFoundException("플레이어 데이터를 찾을 수 없습니다.");
 
         var resource = await _playerResourceRepository.FindByPlayerIdAsync(player.Id)
@@ -52,7 +51,7 @@ public class GoldDungeonService : IGoldDungeonService
             resource.UpdateChangeData(null, resource.Mithril + 1, null);
 
         await _playerResourceRepository.UpdateAsync(resource);
-        await _playerRedisRepository.DeleteAsync(accountId, jobType);
+        await _playerRedisRepository.DeleteAsync(accountId);
 
         return new GoldDungeonResponse(earnedGold, mithrilDropped);
     }

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/Interface/IBasicDungeonClaimService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/Interface/IBasicDungeonClaimService.cs
@@ -1,9 +1,8 @@
 using Fantasy.Server.Domain.Dungeon.Dto.Response;
-using Fantasy.Server.Domain.Player.Enum;
 
 namespace Fantasy.Server.Domain.Dungeon.Service.Interface;
 
 public interface IBasicDungeonClaimService
 {
-    Task<BasicDungeonClaimResponse> ExecuteAsync(JobType jobType);
+    Task<BasicDungeonClaimResponse> ExecuteAsync();
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/Interface/IBossDungeonService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/Interface/IBossDungeonService.cs
@@ -1,9 +1,8 @@
 using Fantasy.Server.Domain.Dungeon.Dto.Response;
-using Fantasy.Server.Domain.Player.Enum;
 
 namespace Fantasy.Server.Domain.Dungeon.Service.Interface;
 
 public interface IBossDungeonService
 {
-    Task<BossDungeonResponse> ExecuteAsync(JobType jobType);
+    Task<BossDungeonResponse> ExecuteAsync();
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/Interface/IGoldDungeonService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/Interface/IGoldDungeonService.cs
@@ -1,10 +1,9 @@
 using Fantasy.Server.Domain.Dungeon.Dto.Request;
 using Fantasy.Server.Domain.Dungeon.Dto.Response;
-using Fantasy.Server.Domain.Player.Enum;
 
 namespace Fantasy.Server.Domain.Dungeon.Service.Interface;
 
 public interface IGoldDungeonService
 {
-    Task<GoldDungeonResponse> ExecuteAsync(JobType jobType, GoldDungeonRequest request);
+    Task<GoldDungeonResponse> ExecuteAsync(GoldDungeonRequest request);
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/Interface/IWeaponDungeonService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/Interface/IWeaponDungeonService.cs
@@ -1,9 +1,8 @@
 using Fantasy.Server.Domain.Dungeon.Dto.Response;
-using Fantasy.Server.Domain.Player.Enum;
 
 namespace Fantasy.Server.Domain.Dungeon.Service.Interface;
 
 public interface IWeaponDungeonService
 {
-    Task<WeaponDungeonResponse> ExecuteAsync(JobType jobType);
+    Task<WeaponDungeonResponse> ExecuteAsync();
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/WeaponDungeonService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/WeaponDungeonService.cs
@@ -4,7 +4,6 @@ using Fantasy.Server.Domain.GameData.Entity;
 using Fantasy.Server.Domain.GameData.Enum;
 using Fantasy.Server.Domain.GameData.Service.Interface;
 using Fantasy.Server.Domain.Player.Dto.Request;
-using Fantasy.Server.Domain.Player.Enum;
 using Fantasy.Server.Domain.Player.Repository.Interface;
 using Fantasy.Server.Global.Security.Provider;
 using Gamism.SDK.Extensions.AspNetCore.Exceptions;
@@ -52,12 +51,14 @@ public class WeaponDungeonService : IWeaponDungeonService
         _calculator = calculator;
     }
 
-    public async Task<WeaponDungeonResponse> ExecuteAsync(JobType jobType)
+    public async Task<WeaponDungeonResponse> ExecuteAsync()
     {
         var accountId = _currentUserProvider.GetAccountId();
 
-        var player = await _playerRepository.FindByAccountAndJobAsync(accountId, jobType)
+        var player = await _playerRepository.FindByAccountAsync(accountId)
             ?? throw new NotFoundException("플레이어 데이터를 찾을 수 없습니다.");
+
+        var jobType = player.JobType;
 
         var resource = await _playerResourceRepository.FindByPlayerIdAsync(player.Id)
             ?? throw new NotFoundException("플레이어 재화 데이터를 찾을 수 없습니다.");
@@ -152,7 +153,7 @@ public class WeaponDungeonService : IWeaponDungeonService
                 await _playerResourceRepository.UpdateAsync(resource);
             }
 
-            await _playerRedisRepository.DeleteAsync(accountId, jobType);
+            await _playerRedisRepository.DeleteAsync(accountId);
         }
 
         return new WeaponDungeonResponse(cleared, droppedWeapons, droppedScrolls);

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Entity/Config/PlayerConfig.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Entity/Config/PlayerConfig.cs
@@ -37,7 +37,7 @@ public class PlayerConfig : IEntityTypeConfiguration<Player>
         builder.Property(p => p.UpdatedAt)
             .IsRequired();
 
-        builder.HasIndex(p => new { p.AccountId, p.JobType })
+        builder.HasIndex(p => p.AccountId)
             .IsUnique();
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Repository/Interface/IPlayerRedisRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Repository/Interface/IPlayerRedisRepository.cs
@@ -1,11 +1,10 @@
 using Fantasy.Server.Domain.Player.Dto.Response;
-using Fantasy.Server.Domain.Player.Enum;
 
 namespace Fantasy.Server.Domain.Player.Repository.Interface;
 
 public interface IPlayerRedisRepository
 {
-    Task SetPlayerDataAsync(long accountId, JobType jobType, PlayerDataResponse data);
-    Task<PlayerDataResponse?> GetPlayerDataAsync(long accountId, JobType jobType);
-    Task DeleteAsync(long accountId, JobType jobType);
+    Task SetPlayerDataAsync(long accountId, PlayerDataResponse data);
+    Task<PlayerDataResponse?> GetPlayerDataAsync(long accountId);
+    Task DeleteAsync(long accountId);
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Repository/Interface/IPlayerRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Repository/Interface/IPlayerRepository.cs
@@ -1,11 +1,10 @@
-using Fantasy.Server.Domain.Player.Enum;
 using PlayerEntity = Fantasy.Server.Domain.Player.Entity.Player;
 
 namespace Fantasy.Server.Domain.Player.Repository.Interface;
 
 public interface IPlayerRepository
 {
-    Task<PlayerEntity?> FindByAccountAndJobAsync(long accountId, JobType jobType);
+    Task<PlayerEntity?> FindByAccountAsync(long accountId);
     Task<PlayerEntity> SaveAsync(PlayerEntity player);
     Task UpdateAsync(PlayerEntity player);
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Repository/PlayerRedisRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Repository/PlayerRedisRepository.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Fantasy.Server.Domain.Player.Dto.Response;
-using Fantasy.Server.Domain.Player.Enum;
 using Fantasy.Server.Domain.Player.Repository.Interface;
 using StackExchange.Redis;
 
@@ -17,25 +16,24 @@ public class PlayerRedisRepository : IPlayerRedisRepository
         _db = multiplexer.GetDatabase();
     }
 
-    private static string CacheKey(long accountId, JobType jobType) =>
-        $"{Prefix}{accountId}:{jobType}";
+    private static string CacheKey(long accountId) => $"{Prefix}{accountId}";
 
-    public async Task SetPlayerDataAsync(long accountId, JobType jobType, PlayerDataResponse data)
+    public async Task SetPlayerDataAsync(long accountId, PlayerDataResponse data)
     {
         var json = JsonSerializer.Serialize(data);
-        await _db.StringSetAsync(CacheKey(accountId, jobType), json, TimeSpan.FromMinutes(30));
+        await _db.StringSetAsync(CacheKey(accountId), json, TimeSpan.FromMinutes(30));
     }
 
-    public async Task<PlayerDataResponse?> GetPlayerDataAsync(long accountId, JobType jobType)
+    public async Task<PlayerDataResponse?> GetPlayerDataAsync(long accountId)
     {
-        var json = await _db.StringGetAsync(CacheKey(accountId, jobType));
+        var json = await _db.StringGetAsync(CacheKey(accountId));
         if (!json.HasValue)
             return null;
         return JsonSerializer.Deserialize<PlayerDataResponse>(json.ToString());
     }
 
-    public async Task DeleteAsync(long accountId, JobType jobType)
+    public async Task DeleteAsync(long accountId)
     {
-        await _db.KeyDeleteAsync(CacheKey(accountId, jobType));
+        await _db.KeyDeleteAsync(CacheKey(accountId));
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Repository/PlayerRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Repository/PlayerRepository.cs
@@ -1,4 +1,3 @@
-using Fantasy.Server.Domain.Player.Enum;
 using Fantasy.Server.Domain.Player.Repository.Interface;
 using Fantasy.Server.Global.Infrastructure;
 using Microsoft.EntityFrameworkCore;
@@ -12,10 +11,10 @@ public class PlayerRepository : IPlayerRepository
 
     public PlayerRepository(AppDbContext db) => _db = db;
 
-    public async Task<PlayerEntity?> FindByAccountAndJobAsync(long accountId, JobType jobType)
+    public async Task<PlayerEntity?> FindByAccountAsync(long accountId)
         => await _db.Players
             .AsNoTracking()
-            .FirstOrDefaultAsync(p => p.AccountId == accountId && p.JobType == jobType);
+            .FirstOrDefaultAsync(p => p.AccountId == accountId);
 
     public async Task<PlayerEntity> SaveAsync(PlayerEntity player)
     {

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Service/EndPlayerSessionService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Service/EndPlayerSessionService.cs
@@ -36,7 +36,7 @@ public class EndPlayerSessionService : IEndPlayerSessionService
     {
         var accountId = _currentUserProvider.GetAccountId();
 
-        var player = await _playerRepository.FindByAccountAndJobAsync(accountId, request.JobType)
+        var player = await _playerRepository.FindByAccountAsync(accountId)
             ?? throw new NotFoundException("플레이어 데이터를 찾을 수 없습니다.");
 
         var session = await _playerSessionRepository.FindByPlayerIdAsync(player.Id)
@@ -62,6 +62,6 @@ public class EndPlayerSessionService : IEndPlayerSessionService
             }
         });
 
-        await _playerRedisRepository.DeleteAsync(accountId, request.JobType);
+        await _playerRedisRepository.DeleteAsync(accountId);
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Service/InitPlayerService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Service/InitPlayerService.cs
@@ -48,11 +48,11 @@ public class InitPlayerService : IInitPlayerService
     {
         long accountId = _currentUserProvider.GetAccountId();
 
-        PlayerDataResponse? cached = await _playerRedisRepository.GetPlayerDataAsync(accountId, request.JobType);
+        PlayerDataResponse? cached = await _playerRedisRepository.GetPlayerDataAsync(accountId);
         if (cached != null)
             return (cached, false);
 
-        PlayerEntity? player = await _playerRepository.FindByAccountAndJobAsync(accountId, request.JobType);
+        PlayerEntity? player = await _playerRepository.FindByAccountAsync(accountId);
         if (player == null)
         {
             var created = await _transactionRunner.ExecuteAsync(async () =>
@@ -83,9 +83,12 @@ public class InitPlayerService : IInitPlayerService
                 createdWeapons,
                 createdSkills);
 
-            await _playerRedisRepository.SetPlayerDataAsync(accountId, request.JobType, createdResponse);
+            await _playerRedisRepository.SetPlayerDataAsync(accountId, createdResponse);
             return (createdResponse, true);
         }
+
+        if (player.JobType != request.JobType)
+            throw new ConflictException("이미 다른 직업의 플레이어가 존재합니다.");
 
         PlayerResource existingResource = await _playerResourceRepository.FindByPlayerIdAsync(player.Id)
             ?? throw new NotFoundException("플레이어 재화 데이터를 찾을 수 없습니다.");
@@ -105,7 +108,7 @@ public class InitPlayerService : IInitPlayerService
             weapons,
             skills);
 
-        await _playerRedisRepository.SetPlayerDataAsync(accountId, request.JobType, response);
+        await _playerRedisRepository.SetPlayerDataAsync(accountId, response);
         return (response, false);
     }
 

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Service/UpdatePlayerLevelService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Service/UpdatePlayerLevelService.cs
@@ -26,12 +26,12 @@ public class UpdatePlayerLevelService : IUpdatePlayerLevelService
     {
         var accountId = _currentUserProvider.GetAccountId();
 
-        var player = await _playerRepository.FindByAccountAndJobAsync(accountId, request.JobType)
+        var player = await _playerRepository.FindByAccountAsync(accountId)
             ?? throw new NotFoundException("플레이어 데이터를 찾을 수 없습니다.");
 
         player.UpdateLevel(request.Level);
         await _playerRepository.UpdateAsync(player);
 
-        await _playerRedisRepository.DeleteAsync(accountId, request.JobType);
+        await _playerRedisRepository.DeleteAsync(accountId);
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Service/UpdatePlayerResourceService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Service/UpdatePlayerResourceService.cs
@@ -29,7 +29,7 @@ public class UpdatePlayerResourceService : IUpdatePlayerResourceService
     {
         var accountId = _currentUserProvider.GetAccountId();
 
-        var player = await _playerRepository.FindByAccountAndJobAsync(accountId, request.JobType)
+        var player = await _playerRepository.FindByAccountAsync(accountId)
             ?? throw new NotFoundException("플레이어 데이터를 찾을 수 없습니다.");
 
         var resource = await _playerResourceRepository.FindByPlayerIdAsync(player.Id)
@@ -38,6 +38,6 @@ public class UpdatePlayerResourceService : IUpdatePlayerResourceService
         resource.UpdateChangeData(request.EnhancementScroll, request.Mithril, request.Sp);
         await _playerResourceRepository.UpdateAsync(resource);
 
-        await _playerRedisRepository.DeleteAsync(accountId, request.JobType);
+        await _playerRedisRepository.DeleteAsync(accountId);
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Service/UpdatePlayerSkillService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Service/UpdatePlayerSkillService.cs
@@ -29,11 +29,11 @@ public class UpdatePlayerSkillService : IUpdatePlayerSkillService
     {
         var accountId = _currentUserProvider.GetAccountId();
 
-        var player = await _playerRepository.FindByAccountAndJobAsync(accountId, request.JobType)
+        var player = await _playerRepository.FindByAccountAsync(accountId)
             ?? throw new NotFoundException("플레이어 데이터를 찾을 수 없습니다.");
 
         await _playerSkillRepository.UpsertRangeAsync(player.Id, request.Skills);
 
-        await _playerRedisRepository.DeleteAsync(accountId, request.JobType);
+        await _playerRedisRepository.DeleteAsync(accountId);
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Service/UpdatePlayerStageService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Service/UpdatePlayerStageService.cs
@@ -29,7 +29,7 @@ public class UpdatePlayerStageService : IUpdatePlayerStageService
     {
         var accountId = _currentUserProvider.GetAccountId();
 
-        var player = await _playerRepository.FindByAccountAndJobAsync(accountId, request.JobType)
+        var player = await _playerRepository.FindByAccountAsync(accountId)
             ?? throw new NotFoundException("플레이어 데이터를 찾을 수 없습니다.");
 
         var stage = await _playerStageRepository.FindByPlayerIdAsync(player.Id)
@@ -38,6 +38,6 @@ public class UpdatePlayerStageService : IUpdatePlayerStageService
         stage.Update(request.MaxStage);
         await _playerStageRepository.UpdateAsync(stage);
 
-        await _playerRedisRepository.DeleteAsync(accountId, request.JobType);
+        await _playerRedisRepository.DeleteAsync(accountId);
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Player/Service/UpdatePlayerWeaponService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Player/Service/UpdatePlayerWeaponService.cs
@@ -29,11 +29,11 @@ public class UpdatePlayerWeaponService : IUpdatePlayerWeaponService
     {
         var accountId = _currentUserProvider.GetAccountId();
 
-        var player = await _playerRepository.FindByAccountAndJobAsync(accountId, request.JobType)
+        var player = await _playerRepository.FindByAccountAsync(accountId)
             ?? throw new NotFoundException("플레이어 데이터를 찾을 수 없습니다.");
 
         await _playerWeaponRepository.UpsertRangeAsync(player.Id, request.Weapons);
 
-        await _playerRedisRepository.DeleteAsync(accountId, request.JobType);
+        await _playerRedisRepository.DeleteAsync(accountId);
     }
 }

--- a/Fantasy-server/Fantasy.Server/Fantasy.Server.csproj
+++ b/Fantasy-server/Fantasy.Server/Fantasy.Server.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
-        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.2.8" />
+        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.3.1" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
 <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">

--- a/Fantasy-server/Fantasy.Server/Migrations/20260608002740_PlayerSinglePerAccount.Designer.cs
+++ b/Fantasy-server/Fantasy.Server/Migrations/20260608002740_PlayerSinglePerAccount.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Fantasy.Server.Global.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Fantasy.Server.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608002740_PlayerSinglePerAccount")]
+    partial class PlayerSinglePerAccount
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Fantasy-server/Fantasy.Server/Migrations/20260608002740_PlayerSinglePerAccount.cs
+++ b/Fantasy-server/Fantasy.Server/Migrations/20260608002740_PlayerSinglePerAccount.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fantasy.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class PlayerSinglePerAccount : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_player_AccountId_JobType",
+                schema: "player",
+                table: "player");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_player_AccountId",
+                schema: "player",
+                table: "player",
+                column: "AccountId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_player_AccountId",
+                schema: "player",
+                table: "player");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_player_AccountId_JobType",
+                schema: "player",
+                table: "player",
+                columns: new[] { "AccountId", "JobType" },
+                unique: true);
+        }
+    }
+}

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/BasicDungeonClaimServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/BasicDungeonClaimServiceTests.cs
@@ -60,12 +60,12 @@ public class BasicDungeonClaimServiceTests
         public async Task NotFoundException이_발생한다()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>())
+            _playerRepository.FindByAccountAsync(Arg.Any<long>())
                 .Returns((PlayerEntity?)null);
 
             var sut = BuildSut(playerRepo: _playerRepository, userProvider: _currentUserProvider);
 
-            var act = async () => await sut.ExecuteAsync(JobType.Warrior);
+            var act = async () => await sut.ExecuteAsync();
 
             await act.Should().ThrowAsync<NotFoundException>();
         }
@@ -84,7 +84,7 @@ public class BasicDungeonClaimServiceTests
         public 경과_시간이_0일_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResource.Create(1L));
@@ -109,7 +109,7 @@ public class BasicDungeonClaimServiceTests
                 skillRepo: _playerSkillRepository,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.EarnedGold.Should().Be(0);
             result.EarnedXp.Should().Be(0);
@@ -133,7 +133,7 @@ public class BasicDungeonClaimServiceTests
         public 오프라인_시간이_있을_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResource.Create(1L));
@@ -172,7 +172,7 @@ public class BasicDungeonClaimServiceTests
                 txRunner: _transactionRunner,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.EarnedGold.Should().BeGreaterThan(0);
             result.EarnedXp.Should().BeGreaterThan(0);
@@ -194,10 +194,10 @@ public class BasicDungeonClaimServiceTests
                 txRunner: _transactionRunner,
                 userProvider: _currentUserProvider);
 
-            await sut.ExecuteAsync(JobType.Warrior);
+            await sut.ExecuteAsync();
 
             await _transactionRunner.Received(1).ExecuteAsync(Arg.Any<Func<Task>>());
-            await _playerRedisRepository.Received(1).DeleteAsync(1L, JobType.Warrior);
+            await _playerRedisRepository.Received(1).DeleteAsync(1L);
         }
     }
 }

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/BossDungeonServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/BossDungeonServiceTests.cs
@@ -61,12 +61,12 @@ public class BossDungeonServiceTests
         public async Task NotFoundException이_발생한다()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>())
+            _playerRepository.FindByAccountAsync(Arg.Any<long>())
                 .Returns((PlayerEntity?)null);
 
             var sut = BuildSut(playerRepo: _playerRepository, userProvider: _currentUserProvider);
 
-            var act = async () => await sut.ExecuteAsync(JobType.Warrior);
+            var act = async () => await sut.ExecuteAsync();
 
             await act.Should().ThrowAsync<NotFoundException>();
         }
@@ -86,7 +86,7 @@ public class BossDungeonServiceTests
         public 전투력이_부족해서_클리어_실패할_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior)); // 레벨 1, 아무 장비 없음
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResource.Create(1L));
@@ -118,7 +118,7 @@ public class BossDungeonServiceTests
                 cache: _gameDataCacheService,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.Cleared.Should().BeFalse();
         }
@@ -136,7 +136,7 @@ public class BossDungeonServiceTests
                 cache: _gameDataCacheService,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.EarnedMithril.Should().Be(0);
             result.DroppedWeapon.Should().BeNull();
@@ -160,7 +160,7 @@ public class BossDungeonServiceTests
         public 전투력이_충분해서_클리어_성공할_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResource.Create(1L));
@@ -201,7 +201,7 @@ public class BossDungeonServiceTests
                 txRunner: _transactionRunner,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.Cleared.Should().BeTrue();
         }
@@ -222,7 +222,7 @@ public class BossDungeonServiceTests
                 txRunner: _transactionRunner,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.EarnedMithril.Should().BeGreaterThan(0);
         }
@@ -243,9 +243,9 @@ public class BossDungeonServiceTests
                 txRunner: _transactionRunner,
                 userProvider: _currentUserProvider);
 
-            await sut.ExecuteAsync(JobType.Warrior);
+            await sut.ExecuteAsync();
 
-            await _playerRedisRepository.Received(1).DeleteAsync(1L, JobType.Warrior);
+            await _playerRedisRepository.Received(1).DeleteAsync(1L);
         }
     }
 
@@ -268,7 +268,7 @@ public class BossDungeonServiceTests
             // atk=100, critRate=0 → dps=100 → dps*30=3000
             // bossHp = monsterHp * 5 = 600 * 5 = 3000 → dps*30 == bossHp → 클리어
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResource.Create(1L));
@@ -307,7 +307,7 @@ public class BossDungeonServiceTests
                 txRunner: _transactionRunner,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.Cleared.Should().BeTrue();
         }

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonServiceTests.cs
@@ -25,7 +25,7 @@ public class GoldDungeonServiceTests
         public 정상_요청일_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResource.Create(1L));
@@ -39,7 +39,7 @@ public class GoldDungeonServiceTests
         {
             var request = new GoldDungeonRequest(Clicks: 10, DurationSeconds: 30);
 
-            var result = await _sut.ExecuteAsync(JobType.Warrior, request);
+            var result = await _sut.ExecuteAsync(request);
 
             result.EarnedGold.Should().Be(10 * 10); // 10 clicks * GoldPerClick(10)
         }
@@ -49,7 +49,7 @@ public class GoldDungeonServiceTests
         {
             var request = new GoldDungeonRequest(Clicks: 10, DurationSeconds: 30);
 
-            await _sut.ExecuteAsync(JobType.Warrior, request);
+            await _sut.ExecuteAsync(request);
 
             await _playerResourceRepository.Received(1).UpdateAsync(Arg.Any<PlayerResource>());
         }
@@ -59,9 +59,9 @@ public class GoldDungeonServiceTests
         {
             var request = new GoldDungeonRequest(Clicks: 10, DurationSeconds: 30);
 
-            await _sut.ExecuteAsync(JobType.Warrior, request);
+            await _sut.ExecuteAsync(request);
 
-            await _playerRedisRepository.Received(1).DeleteAsync(1L, JobType.Warrior);
+            await _playerRedisRepository.Received(1).DeleteAsync(1L);
         }
     }
 
@@ -86,7 +86,7 @@ public class GoldDungeonServiceTests
             // MaxCPS = 15, DurationSeconds = 30 → 최대 클릭 = 450
             var request = new GoldDungeonRequest(Clicks: 451, DurationSeconds: 30);
 
-            var act = async () => await _sut.ExecuteAsync(JobType.Warrior, request);
+            var act = async () => await _sut.ExecuteAsync(request);
 
             await act.Should().ThrowAsync<BadRequestException>();
         }
@@ -96,7 +96,7 @@ public class GoldDungeonServiceTests
         {
             var request = new GoldDungeonRequest(Clicks: 1000, DurationSeconds: 30);
 
-            var act = () => _sut.ExecuteAsync(JobType.Warrior, request);
+            var act = () => _sut.ExecuteAsync(request);
 
             await act.Should().ThrowAsync<BadRequestException>();
             await _playerResourceRepository.DidNotReceive().UpdateAsync(Arg.Any<PlayerResource>());
@@ -114,7 +114,7 @@ public class GoldDungeonServiceTests
         public 플레이어가_없을_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>())
+            _playerRepository.FindByAccountAsync(Arg.Any<long>())
                 .Returns((PlayerEntity?)null);
 
             _sut = new GoldDungeonService(
@@ -126,7 +126,7 @@ public class GoldDungeonServiceTests
         {
             var request = new GoldDungeonRequest(Clicks: 10, DurationSeconds: 30);
 
-            var act = async () => await _sut.ExecuteAsync(JobType.Warrior, request);
+            var act = async () => await _sut.ExecuteAsync(request);
 
             await act.Should().ThrowAsync<NotFoundException>();
         }

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/WeaponDungeonServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/WeaponDungeonServiceTests.cs
@@ -55,12 +55,12 @@ public class WeaponDungeonServiceTests
         public async Task NotFoundException이_발생한다()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>())
+            _playerRepository.FindByAccountAsync(Arg.Any<long>())
                 .Returns((PlayerEntity?)null);
 
             var sut = BuildSut(playerRepo: _playerRepository, userProvider: _currentUserProvider);
 
-            var act = async () => await sut.ExecuteAsync(JobType.Warrior);
+            var act = async () => await sut.ExecuteAsync();
 
             await act.Should().ThrowAsync<NotFoundException>();
         }
@@ -81,7 +81,7 @@ public class WeaponDungeonServiceTests
         public 전투력이_부족해서_클리어_실패할_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior)); // 레벨 1, 장비 없음
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResource.Create(1L));
@@ -114,7 +114,7 @@ public class WeaponDungeonServiceTests
                 cache: _gameDataCacheService,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.Cleared.Should().BeFalse();
         }
@@ -133,7 +133,7 @@ public class WeaponDungeonServiceTests
                 cache: _gameDataCacheService,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.DroppedWeapons.Should().BeEmpty();
             result.DroppedScrolls.Should().Be(0);
@@ -153,9 +153,9 @@ public class WeaponDungeonServiceTests
                 cache: _gameDataCacheService,
                 userProvider: _currentUserProvider);
 
-            await sut.ExecuteAsync(JobType.Warrior);
+            await sut.ExecuteAsync();
 
-            await _playerRedisRepository.DidNotReceive().DeleteAsync(Arg.Any<long>(), Arg.Any<JobType>());
+            await _playerRedisRepository.DidNotReceive().DeleteAsync(Arg.Any<long>());
         }
     }
 
@@ -174,7 +174,7 @@ public class WeaponDungeonServiceTests
         public 전투력이_충분해서_클리어_성공할_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResource.Create(1L));
@@ -208,7 +208,7 @@ public class WeaponDungeonServiceTests
                 cache: _gameDataCacheService,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.Cleared.Should().BeTrue();
         }
@@ -230,7 +230,7 @@ public class WeaponDungeonServiceTests
         {
             // atk=100, critRate=0 → dps=100 → dps*30=3000 == monsterHp=3000 → 클리어
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResource.Create(1L));
@@ -263,7 +263,7 @@ public class WeaponDungeonServiceTests
                 cache: _gameDataCacheService,
                 userProvider: _currentUserProvider);
 
-            var result = await sut.ExecuteAsync(JobType.Warrior);
+            var result = await sut.ExecuteAsync();
 
             result.Cleared.Should().BeTrue();
         }

--- a/Fantasy-server/Fantasy.Test/Fantasy.Test.csproj
+++ b/Fantasy-server/Fantasy.Test/Fantasy.Test.csproj
@@ -23,7 +23,7 @@
         </PackageReference>
 
         <PackageReference Include="FluentAssertions" Version="8.9.0" />
-        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.2.8" />
+        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.3.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/Fantasy-server/Fantasy.Test/Player/Service/EndPlayerSessionServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Player/Service/EndPlayerSessionServiceTests.cs
@@ -32,7 +32,7 @@ public class EndPlayerSessionServiceTests
             _transactionRunner.ExecuteAsync(Arg.Any<Func<Task>>())
                 .Returns(callInfo => callInfo.Arg<Func<Task>>()());
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerSessionRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerSession.Create(1L));
@@ -85,7 +85,7 @@ public class EndPlayerSessionServiceTests
         {
             await _sut.ExecuteAsync(_request);
 
-            await _playerRedisRepository.Received(1).DeleteAsync(1L, JobType.Warrior);
+            await _playerRedisRepository.Received(1).DeleteAsync(1L);
         }
     }
 
@@ -105,7 +105,7 @@ public class EndPlayerSessionServiceTests
             _transactionRunner.ExecuteAsync(Arg.Any<Func<Task>>())
                 .Returns(callInfo => callInfo.Arg<Func<Task>>()());
             _currentUserProvider.GetAccountId().Returns(2L);
-            _playerRepository.FindByAccountAndJobAsync(2L, JobType.Archer)
+            _playerRepository.FindByAccountAsync(2L)
                 .Returns(PlayerEntity.Create(2L, JobType.Archer));
             _playerSessionRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerSession.Create(2L));
@@ -148,7 +148,7 @@ public class EndPlayerSessionServiceTests
         {
             await _sut.ExecuteAsync(_request);
 
-            await _playerRedisRepository.Received(1).DeleteAsync(2L, JobType.Archer);
+            await _playerRedisRepository.Received(1).DeleteAsync(2L);
         }
     }
 
@@ -165,7 +165,7 @@ public class EndPlayerSessionServiceTests
         public 플레이어가_존재하지_않을_때()
         {
             _currentUserProvider.GetAccountId().Returns(99L);
-            _playerRepository.FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>())
+            _playerRepository.FindByAccountAsync(Arg.Any<long>())
                 .Returns((PlayerEntity?)null);
 
             _sut = new EndPlayerSessionService(

--- a/Fantasy-server/Fantasy.Test/Player/Service/InitPlayerServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Player/Service/InitPlayerServiceTests.cs
@@ -7,6 +7,7 @@ using Fantasy.Server.Domain.Player.Service;
 using Fantasy.Server.Global.Infrastructure;
 using Fantasy.Server.Global.Security.Provider;
 using FluentAssertions;
+using Gamism.SDK.Extensions.AspNetCore.Exceptions;
 using NSubstitute;
 using Xunit;
 using PlayerEntity = Fantasy.Server.Domain.Player.Entity.Player;
@@ -35,7 +36,7 @@ public class InitPlayerServiceTests
         public 캐시가_있을_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRedisRepository.GetPlayerDataAsync(1L, JobType.Warrior).Returns(_cached);
+            _playerRedisRepository.GetPlayerDataAsync(1L).Returns(_cached);
 
             _sut = new InitPlayerService(
                 _playerRepository,
@@ -62,7 +63,7 @@ public class InitPlayerServiceTests
         {
             await _sut.ExecuteAsync(_request);
 
-            await _playerRepository.DidNotReceive().FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>());
+            await _playerRepository.DidNotReceive().FindByAccountAsync(Arg.Any<long>());
         }
 
         [Fact]
@@ -102,8 +103,8 @@ public class InitPlayerServiceTests
             _transactionRunner.ExecuteAsync(Arg.Any<Func<Task<(PlayerEntity Player, PlayerResource Resource, PlayerStage Stage, PlayerSession Session)>>>())
                 .Returns(callInfo => callInfo.Arg<Func<Task<(PlayerEntity, PlayerResource, PlayerStage, PlayerSession)>>>()());
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRedisRepository.GetPlayerDataAsync(1L, JobType.Warrior).Returns((PlayerDataResponse?)null);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior).Returns((PlayerEntity?)null);
+            _playerRedisRepository.GetPlayerDataAsync(1L).Returns((PlayerDataResponse?)null);
+            _playerRepository.FindByAccountAsync(1L).Returns((PlayerEntity?)null);
             _playerRepository.SaveAsync(Arg.Any<PlayerEntity>())
                 .Returns(callInfo => callInfo.Arg<PlayerEntity>());
             _playerResourceRepository.SaveAsync(Arg.Any<PlayerResourceEntity>())
@@ -182,7 +183,7 @@ public class InitPlayerServiceTests
             await _sut.ExecuteAsync(_request);
 
             await _playerRedisRepository.Received(1)
-                .SetPlayerDataAsync(1L, JobType.Warrior, Arg.Any<PlayerDataResponse>());
+                .SetPlayerDataAsync(1L, Arg.Any<PlayerDataResponse>());
         }
     }
 
@@ -203,8 +204,8 @@ public class InitPlayerServiceTests
         public 기존_플레이어일_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRedisRepository.GetPlayerDataAsync(1L, JobType.Warrior).Returns((PlayerDataResponse?)null);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRedisRepository.GetPlayerDataAsync(1L).Returns((PlayerDataResponse?)null);
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResourceEntity.Create(1L));
@@ -267,7 +268,57 @@ public class InitPlayerServiceTests
             await _sut.ExecuteAsync(_request);
 
             await _playerRedisRepository.Received(1)
-                .SetPlayerDataAsync(1L, JobType.Warrior, Arg.Any<PlayerDataResponse>());
+                .SetPlayerDataAsync(1L, Arg.Any<PlayerDataResponse>());
+        }
+    }
+
+    public class 다른_직업으로_재초기화_요청할_때
+    {
+        private readonly IPlayerRepository _playerRepository = Substitute.For<IPlayerRepository>();
+        private readonly IPlayerResourceRepository _playerResourceRepository = Substitute.For<IPlayerResourceRepository>();
+        private readonly IPlayerStageRepository _playerStageRepository = Substitute.For<IPlayerStageRepository>();
+        private readonly IPlayerSessionRepository _playerSessionRepository = Substitute.For<IPlayerSessionRepository>();
+        private readonly IPlayerWeaponRepository _playerWeaponRepository = Substitute.For<IPlayerWeaponRepository>();
+        private readonly IPlayerSkillRepository _playerSkillRepository = Substitute.For<IPlayerSkillRepository>();
+        private readonly IPlayerRedisRepository _playerRedisRepository = Substitute.For<IPlayerRedisRepository>();
+        private readonly ICurrentUserProvider _currentUserProvider = Substitute.For<ICurrentUserProvider>();
+        private readonly IAppDbTransactionRunner _transactionRunner = Substitute.For<IAppDbTransactionRunner>();
+        private readonly InitPlayerService _sut;
+        private readonly InitPlayerRequest _request = new(JobType.Mage);
+
+        public 다른_직업으로_재초기화_요청할_때()
+        {
+            _currentUserProvider.GetAccountId().Returns(1L);
+            _playerRedisRepository.GetPlayerDataAsync(1L).Returns((PlayerDataResponse?)null);
+            _playerRepository.FindByAccountAsync(1L)
+                .Returns(PlayerEntity.Create(1L, JobType.Warrior));
+
+            _sut = new InitPlayerService(
+                _playerRepository,
+                _playerResourceRepository,
+                _playerStageRepository,
+                _playerSessionRepository,
+                _playerWeaponRepository,
+                _playerSkillRepository,
+                _playerRedisRepository,
+                _currentUserProvider,
+                _transactionRunner);
+        }
+
+        [Fact]
+        public async Task ConflictException이_발생한다()
+        {
+            Func<Task> act = () => _sut.ExecuteAsync(_request);
+
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Fact]
+        public async Task 새_플레이어가_저장되지_않는다()
+        {
+            await Assert.ThrowsAsync<ConflictException>(() => _sut.ExecuteAsync(_request));
+
+            await _playerRepository.DidNotReceive().SaveAsync(Arg.Any<PlayerEntity>());
         }
     }
 }

--- a/Fantasy-server/Fantasy.Test/Player/Service/UpdatePlayerLevelServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Player/Service/UpdatePlayerLevelServiceTests.cs
@@ -24,7 +24,7 @@ public class UpdatePlayerLevelServiceTests
         public 플레이어가_존재할_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
 
             _sut = new UpdatePlayerLevelService(_playerRepository, _playerRedisRepository, _currentUserProvider);
@@ -43,7 +43,7 @@ public class UpdatePlayerLevelServiceTests
         {
             await _sut.ExecuteAsync(_request);
 
-            await _playerRedisRepository.Received(1).DeleteAsync(1L, JobType.Warrior);
+            await _playerRedisRepository.Received(1).DeleteAsync(1L);
         }
     }
 
@@ -57,7 +57,7 @@ public class UpdatePlayerLevelServiceTests
         public 플레이어가_존재하지_않을_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>())
+            _playerRepository.FindByAccountAsync(Arg.Any<long>())
                 .Returns((PlayerEntity?)null);
 
             _sut = new UpdatePlayerLevelService(_playerRepository, _playerRedisRepository, _currentUserProvider);

--- a/Fantasy-server/Fantasy.Test/Player/Service/UpdatePlayerResourceServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Player/Service/UpdatePlayerResourceServiceTests.cs
@@ -25,7 +25,7 @@ public class UpdatePlayerResourceServiceTests
         public 정상_요청일_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerResourceRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerResourceEntity.Create(1L));
@@ -61,7 +61,7 @@ public class UpdatePlayerResourceServiceTests
 
             await _sut.ExecuteAsync(request);
 
-            await _playerRedisRepository.Received(1).DeleteAsync(1L, JobType.Warrior);
+            await _playerRedisRepository.Received(1).DeleteAsync(1L);
         }
     }
 
@@ -76,7 +76,7 @@ public class UpdatePlayerResourceServiceTests
         public 플레이어가_존재하지_않을_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>())
+            _playerRepository.FindByAccountAsync(Arg.Any<long>())
                 .Returns((PlayerEntity?)null);
 
             _sut = new UpdatePlayerResourceService(

--- a/Fantasy-server/Fantasy.Test/Player/Service/UpdatePlayerSkillServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Player/Service/UpdatePlayerSkillServiceTests.cs
@@ -25,7 +25,7 @@ public class UpdatePlayerSkillServiceTests
         public 정상_요청일_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
 
             _sut = new UpdatePlayerSkillService(
@@ -49,7 +49,7 @@ public class UpdatePlayerSkillServiceTests
 
             await _sut.ExecuteAsync(request);
 
-            await _playerRedisRepository.Received(1).DeleteAsync(1L, JobType.Warrior);
+            await _playerRedisRepository.Received(1).DeleteAsync(1L);
         }
     }
 
@@ -64,7 +64,7 @@ public class UpdatePlayerSkillServiceTests
         public 플레이어가_존재하지_않을_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>())
+            _playerRepository.FindByAccountAsync(Arg.Any<long>())
                 .Returns((PlayerEntity?)null);
 
             _sut = new UpdatePlayerSkillService(

--- a/Fantasy-server/Fantasy.Test/Player/Service/UpdatePlayerStageServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Player/Service/UpdatePlayerStageServiceTests.cs
@@ -26,7 +26,7 @@ public class UpdatePlayerStageServiceTests
         public 정상_요청일_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerStageRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns(PlayerStage.Create(1L));
@@ -48,7 +48,7 @@ public class UpdatePlayerStageServiceTests
         {
             await _sut.ExecuteAsync(_request);
 
-            await _playerRedisRepository.Received(1).DeleteAsync(1L, JobType.Warrior);
+            await _playerRedisRepository.Received(1).DeleteAsync(1L);
         }
     }
 
@@ -63,7 +63,7 @@ public class UpdatePlayerStageServiceTests
         public 플레이어가_존재하지_않을_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>())
+            _playerRepository.FindByAccountAsync(Arg.Any<long>())
                 .Returns((PlayerEntity?)null);
 
             _sut = new UpdatePlayerStageService(
@@ -92,7 +92,7 @@ public class UpdatePlayerStageServiceTests
         public 스테이지_데이터가_존재하지_않을_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
             _playerStageRepository.FindByPlayerIdAsync(Arg.Any<long>())
                 .Returns((PlayerStage?)null);

--- a/Fantasy-server/Fantasy.Test/Player/Service/UpdatePlayerWeaponServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Player/Service/UpdatePlayerWeaponServiceTests.cs
@@ -25,7 +25,7 @@ public class UpdatePlayerWeaponServiceTests
         public 정상_요청일_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(1L, JobType.Warrior)
+            _playerRepository.FindByAccountAsync(1L)
                 .Returns(PlayerEntity.Create(1L, JobType.Warrior));
 
             _sut = new UpdatePlayerWeaponService(
@@ -49,7 +49,7 @@ public class UpdatePlayerWeaponServiceTests
 
             await _sut.ExecuteAsync(request);
 
-            await _playerRedisRepository.Received(1).DeleteAsync(1L, JobType.Warrior);
+            await _playerRedisRepository.Received(1).DeleteAsync(1L);
         }
     }
 
@@ -64,7 +64,7 @@ public class UpdatePlayerWeaponServiceTests
         public 플레이어가_존재하지_않을_때()
         {
             _currentUserProvider.GetAccountId().Returns(1L);
-            _playerRepository.FindByAccountAndJobAsync(Arg.Any<long>(), Arg.Any<JobType>())
+            _playerRepository.FindByAccountAsync(Arg.Any<long>())
                 .Returns((PlayerEntity?)null);
 
             _sut = new UpdatePlayerWeaponService(


### PR DESCRIPTION
## 개요

계정 하나가 여러 직업의 플레이어를 가질 수 있던 구조를 **계정당 플레이어 1개**로 제한하는 모델로 전환합니다.

---

## 변경 사항

### DB / 엔티티
- `PlayerConfig`: `(AccountId, JobType)` 복합 유니크 인덱스 → `AccountId` 단독 유니크 인덱스로 변경
- 마이그레이션 `20260608002740_PlayerSinglePerAccount` 추가

### 리포지토리
- `IPlayerRepository.FindByAccountAndJobAsync(accountId, jobType)` → `FindByAccountAsync(accountId)`
- `IPlayerRedisRepository`: `SetPlayerDataAsync / GetPlayerDataAsync / DeleteAsync` 모두 `jobType` 파라미터 제거 — Redis 키를 `player:{accountId}`로 단순화

### 서비스
- `InitPlayerService`: 계정에 이미 플레이어가 존재할 때 **다른 직업**으로 재초기화를 시도하면 `ConflictException` (409) 발생
- 던전 서비스 6종 (`BasicDungeonClaimService`, `BossDungeonService`, `GoldDungeonService`, `WeaponDungeonService` 등): 플레이어 조회 파라미터에서 `jobType` 제거

### 테스트
- `InitPlayerServiceTests`: 다른 직업으로 재초기화 시도 → 409 케이스 추가
- 던전 서비스 테스트 시그니처 업데이트

---

## 테스트 결과

빌드 성공 및 전체 테스트 통과 확인