### PR TITLE
fix: 배포 안정화 및 보안 하드닝 적용

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -6,14 +6,14 @@ allowed-tools: Bash(dotnet build:*), Bash(dotnet test:*)
 context: fork
 ---
 
-Build the server project, then run the test suite and report results.
+Build the test project (which also builds the server via project reference), then run the test suite and report results.
 
 ## Steps
 
 ### Step 1 — Build
 
 ```bash
-dotnet build Fantasy.Server/Fantasy.Server.csproj
+dotnet build Fantasy-server/Fantasy.Test/Fantasy.Test.csproj
 ```
 
 - Build **fails**: list each error with its file path and line number, explain the likely cause, then stop.
@@ -24,13 +24,13 @@ dotnet build Fantasy.Server/Fantasy.Server.csproj
 If `$ARGUMENTS` is empty, run all tests:
 
 ```bash
-dotnet test Fantasy.Test/Fantasy.Test.csproj --no-build
+dotnet test Fantasy-server/Fantasy.Test/Fantasy.Test.csproj --no-build
 ```
 
 If `$ARGUMENTS` is provided, filter by class or method name:
 
 ```bash
-dotnet test Fantasy.Test/Fantasy.Test.csproj --no-build --filter "FullyQualifiedName~$ARGUMENTS"
+dotnet test Fantasy-server/Fantasy.Test/Fantasy.Test.csproj --no-build --filter "FullyQualifiedName~$ARGUMENTS"
 ```
 
 ### Step 3 — Report Results

--- a/.github/workflows/fantasy-prod-cd.yml
+++ b/.github/workflows/fantasy-prod-cd.yml
@@ -118,13 +118,27 @@ jobs:
               "${{ secrets.REDIS_CONNECTION_STRING }}" \
               "${{ secrets.JWT_SECRET_KEY }}" \
               > ~/deploy/.env
+            chmod 600 ~/deploy/.env
 
             docker compose -f ~/deploy/compose.prod.yaml --env-file ~/deploy/.env pull
             docker compose -f ~/deploy/compose.prod.yaml --env-file ~/deploy/.env up -d
 
-            sleep 5
-            docker ps | grep fantasy-server
+            for i in $(seq 1 30); do
+              STATUS=$(docker inspect --format='{{.State.Health.Status}}' fantasy-server 2>/dev/null || echo "missing")
+              if [ "$STATUS" = "healthy" ]; then
+                break
+              fi
+              if [ "$i" -eq 30 ]; then
+                echo "fantasy-server did not become healthy in time (status: $STATUS)"
+                docker logs fantasy-server --tail 50
+                exit 1
+              fi
+              sleep 3
+            done
+
+            echo "fantasy-server is healthy"
             docker logs fantasy-server --tail 20
+            docker image prune -f
 
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/fantasy-prod-cd.yml
+++ b/.github/workflows/fantasy-prod-cd.yml
@@ -110,13 +110,14 @@ jobs:
           script: |
             mkdir -p ~/deploy
 
-            printf 'POSTGRES_USER=%s\nPOSTGRES_PASSWORD=%s\nDOCKER_USERNAME=%s\nDB_CONNECTION_STRING=%s\nREDIS_CONNECTION_STRING=%s\nJWT_SECRET_KEY=%s\n' \
+            printf 'POSTGRES_USER=%s\nPOSTGRES_PASSWORD=%s\nDOCKER_USERNAME=%s\nDB_CONNECTION_STRING=%s\nREDIS_CONNECTION_STRING=%s\nJWT_SECRET_KEY=%s\nSWAGGER_PASSWORD=%s\n' \
               "${{ secrets.POSTGRES_USER }}" \
               "${{ secrets.POSTGRES_PASSWORD }}" \
               "${{ secrets.DOCKER_USERNAME }}" \
               "${{ secrets.DB_CONNECTION_STRING }}" \
               "${{ secrets.REDIS_CONNECTION_STRING }}" \
               "${{ secrets.JWT_SECRET_KEY }}" \
+              "${{ secrets.SWAGGER_PASSWORD }}" \
               > ~/deploy/.env
             chmod 600 ~/deploy/.env
 

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/GoldDungeonClaimService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/GoldDungeonClaimService.cs
@@ -26,6 +26,7 @@ public class GoldDungeonClaimService : IGoldDungeonClaimService
     private readonly IRandomProvider _randomProvider;
     private readonly IAppDbTransactionRunner _transactionRunner;
     private readonly ICurrentUserProvider _currentUserProvider;
+    private readonly TimeProvider _timeProvider;
 
     public GoldDungeonClaimService(
         IPlayerRepository playerRepository,
@@ -38,7 +39,8 @@ public class GoldDungeonClaimService : IGoldDungeonClaimService
         IGoldDungeonRunRepository goldDungeonRunRepository,
         IRandomProvider randomProvider,
         IAppDbTransactionRunner transactionRunner,
-        ICurrentUserProvider currentUserProvider)
+        ICurrentUserProvider currentUserProvider,
+        TimeProvider timeProvider)
     {
         _playerRepository = playerRepository;
         _playerResourceRepository = playerResourceRepository;
@@ -51,6 +53,7 @@ public class GoldDungeonClaimService : IGoldDungeonClaimService
         _randomProvider = randomProvider;
         _transactionRunner = transactionRunner;
         _currentUserProvider = currentUserProvider;
+        _timeProvider = timeProvider;
     }
 
     public async Task<GoldDungeonClaimResponse> ExecuteAsync(Guid runId, GoldDungeonClaimRequest request)
@@ -98,11 +101,18 @@ public class GoldDungeonClaimService : IGoldDungeonClaimService
             return new GoldDungeonClaimResponse(run.Id, run.EarnedGold!.Value, run.EarnedMithril!.Value, idempotentChanges, playerResponse);
         }
 
-        if (DateTime.UtcNow > run.ExpiresAt)
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        if (now > run.ExpiresAt)
             throw new BadRequestException("골드 던전 제한 시간이 초과되었습니다.");
 
         if (request.Clicks > run.MaxClicks)
             throw new BadRequestException("비정상적인 클릭 횟수입니다.");
+
+        var elapsedSeconds = Math.Clamp((now - run.StartedAt).TotalSeconds, 0, run.DurationSeconds);
+        var maxAllowedClicks = (int)Math.Ceiling(elapsedSeconds * run.MaxClicks / run.DurationSeconds);
+        if (request.Clicks > maxAllowedClicks)
+            throw new BadRequestException("경과 시간 대비 비정상적인 클릭 횟수입니다.");
 
         var earnedGold = request.Clicks * GoldPerClick;
         var mithrilDropped = _randomProvider.Next(0, 100) < MithrilDropRatePercent;

--- a/Fantasy-server/Fantasy.Server/Global/Config/JwtConfig.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Config/JwtConfig.cs
@@ -23,6 +23,7 @@ public static class JwtConfig
             options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
         }).AddJwtBearer(options =>
         {
+            options.MapInboundClaims = false;
             options.TokenValidationParameters = new TokenValidationParameters
             {
                 ValidateIssuer = true,

--- a/Fantasy-server/Fantasy.Server/Global/Security/SwaggerBasicAuthMiddleware.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Security/SwaggerBasicAuthMiddleware.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Fantasy.Server.Global.Security;
@@ -55,6 +56,11 @@ public class SwaggerBasicAuthMiddleware
 
         // "username:password" 형식 — username은 검사하지 않음
         var separatorIndex = decoded.IndexOf(':');
-        return separatorIndex >= 0 && decoded[(separatorIndex + 1)..] == _password;
+        if (separatorIndex < 0)
+            return false;
+
+        var inputPasswordBytes = Encoding.UTF8.GetBytes(decoded[(separatorIndex + 1)..]);
+        var expectedPasswordBytes = Encoding.UTF8.GetBytes(_password ?? string.Empty);
+        return CryptographicOperations.FixedTimeEquals(inputPasswordBytes, expectedPasswordBytes);
     }
 }

--- a/Fantasy-server/Fantasy.Server/Global/Security/SwaggerBasicAuthMiddleware.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Security/SwaggerBasicAuthMiddleware.cs
@@ -1,0 +1,60 @@
+using System.Text;
+
+namespace Fantasy.Server.Global.Security;
+
+public class SwaggerBasicAuthMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly string? _password;
+
+    public SwaggerBasicAuthMiddleware(RequestDelegate next, IConfiguration configuration)
+    {
+        _next = next;
+        _password = configuration["Swagger:Password"];
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!context.Request.Path.StartsWithSegments("/swagger"))
+        {
+            await _next(context);
+            return;
+        }
+
+        // 비밀번호 미설정 배포에서 Swagger가 무방비 노출되지 않도록 경로 자체를 숨김
+        if (string.IsNullOrEmpty(_password))
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        if (!IsAuthorized(context.Request.Headers.Authorization.ToString()))
+        {
+            context.Response.Headers.WWWAuthenticate = "Basic realm=\"swagger\"";
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return;
+        }
+
+        await _next(context);
+    }
+
+    private bool IsAuthorized(string authorizationHeader)
+    {
+        if (!authorizationHeader.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        string decoded;
+        try
+        {
+            decoded = Encoding.UTF8.GetString(Convert.FromBase64String(authorizationHeader["Basic ".Length..]));
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        // "username:password" 형식 — username은 검사하지 않음
+        var separatorIndex = decoded.IndexOf(':');
+        return separatorIndex >= 0 && decoded[(separatorIndex + 1)..] == _password;
+    }
+}

--- a/Fantasy-server/Fantasy.Server/Program.cs
+++ b/Fantasy-server/Fantasy.Server/Program.cs
@@ -47,8 +47,8 @@ await using (var scope = app.Services.CreateAsyncScope())
 }
 
 app.UseGamismSdk();
-app.UseRateLimiter();
 app.UseAuthentication();
+app.UseRateLimiter();
 app.UseAuthorization();
 app.MapControllers();
 app.Run();

--- a/Fantasy-server/Fantasy.Server/Program.cs
+++ b/Fantasy-server/Fantasy.Server/Program.cs
@@ -7,6 +7,7 @@ using Fantasy.Server.Domain.LevelUp.Config;
 using Fantasy.Server.Domain.Player.Config;
 using Fantasy.Server.Global.Config;
 using Fantasy.Server.Global.Infrastructure;
+using Fantasy.Server.Global.Security;
 using Fantasy.Server.Global.Security.Config;
 using Gamism.SDK.Extensions.AspNetCore;
 using Microsoft.EntityFrameworkCore;
@@ -45,6 +46,10 @@ await using (var scope = app.Services.CreateAsyncScope())
     await db.Database.MigrateAsync();
     await GameDataSeeder.SeedAsync(db, logger);
 }
+
+// Gamism SDK는 환경 구분 없이 Swagger를 노출하므로 Production에서는 Basic Auth로 보호
+if (app.Environment.IsProduction())
+    app.UseMiddleware<SwaggerBasicAuthMiddleware>();
 
 app.UseGamismSdk();
 app.UseAuthentication();

--- a/Fantasy-server/Fantasy.Server/Program.cs
+++ b/Fantasy-server/Fantasy.Server/Program.cs
@@ -17,8 +17,8 @@ builder.Services.AddControllers();
 builder.Services.AddGamismSdk(options =>
 {
     options.Swagger.Title = "Fantasy API";
-    options.Logging.NotLoggingUrls = ["/swagger/**", "/health"];
-    options.Response.NotWrappingUrls = ["/swagger/**", "/health"];
+    options.Logging.NotLoggingUrls = ["/swagger/**", "/v1/health"];
+    options.Response.NotWrappingUrls = ["/swagger/**", "/v1/health"];
 });
 
 builder.Services.AddDatabase(builder.Configuration);

--- a/Fantasy-server/Fantasy.Server/Program.cs
+++ b/Fantasy-server/Fantasy.Server/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddDatabase(builder.Configuration);
 builder.Services.AddRedis(builder.Configuration, "fantasy:");
 builder.Services.AddJwtAuthentication(builder.Configuration);
 builder.Services.AddHttpContextAccessor();
+builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddRateLimit();
 
 builder.Services.AddAccountServices();

--- a/Fantasy-server/Fantasy.Server/deploy/compose.prod.yaml
+++ b/Fantasy-server/Fantasy.Server/deploy/compose.prod.yaml
@@ -10,6 +10,11 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./docker/postgres/init.sh:/docker-entrypoint-initdb.d/init.sh:ro
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   fantasy-redis:
     image: redis:7-alpine
@@ -17,6 +22,11 @@ services:
     volumes:
       - redis_data:/data
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   fantasy-server:
     image: ${DOCKER_USERNAME}/fantasy-server:latest
@@ -29,8 +39,10 @@ services:
       - ConnectionStrings__Redis=${REDIS_CONNECTION_STRING}
       - Jwt__SecretKey=${JWT_SECRET_KEY}
     depends_on:
-      - fantasy-db
-      - fantasy-redis
+      fantasy-db:
+        condition: service_healthy
+      fantasy-redis:
+        condition: service_healthy
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/v1/health"]

--- a/Fantasy-server/Fantasy.Server/deploy/compose.prod.yaml
+++ b/Fantasy-server/Fantasy.Server/deploy/compose.prod.yaml
@@ -38,6 +38,7 @@ services:
       - ConnectionStrings__Database=${DB_CONNECTION_STRING}
       - ConnectionStrings__Redis=${REDIS_CONNECTION_STRING}
       - Jwt__SecretKey=${JWT_SECRET_KEY}
+      - Swagger__Password=${SWAGGER_PASSWORD}
     depends_on:
       fantasy-db:
         condition: service_healthy

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonClaimServiceTest.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/GoldDungeonClaimServiceTest.cs
@@ -30,7 +30,8 @@ public class GoldDungeonClaimServiceTest
         IGoldDungeonRunRepository? runRepo = null,
         IRandomProvider? randomProvider = null,
         IAppDbTransactionRunner? txRunner = null,
-        ICurrentUserProvider? userProvider = null) =>
+        ICurrentUserProvider? userProvider = null,
+        TimeProvider? timeProvider = null) =>
         new(
             playerRepo ?? Substitute.For<IPlayerRepository>(),
             resourceRepo ?? Substitute.For<IPlayerResourceRepository>(),
@@ -42,7 +43,15 @@ public class GoldDungeonClaimServiceTest
             runRepo ?? Substitute.For<IGoldDungeonRunRepository>(),
             randomProvider ?? Substitute.For<IRandomProvider>(),
             txRunner ?? Substitute.For<IAppDbTransactionRunner>(),
-            userProvider ?? Substitute.For<ICurrentUserProvider>());
+            userProvider ?? Substitute.For<ICurrentUserProvider>(),
+            timeProvider ?? FixedTimeProvider(DateTimeOffset.UtcNow));
+
+    private static TimeProvider FixedTimeProvider(DateTimeOffset now)
+    {
+        var timeProvider = Substitute.For<TimeProvider>();
+        timeProvider.GetUtcNow().Returns(now);
+        return timeProvider;
+    }
 
     private static void SetupPlayerData(
         IPlayerRepository playerRepo,
@@ -144,11 +153,179 @@ public class GoldDungeonClaimServiceTest
             var run = GoldDungeonRun.Create(accountId: 1L, durationSeconds: 30, maxClicksPerSecond: 15);
             runRepo.FindByIdAsync(run.Id).Returns(run);
 
-            var sut = BuildSut(runRepo: runRepo, userProvider: userProvider);
+            var sut = BuildSut(runRepo: runRepo, userProvider: userProvider,
+                timeProvider: FixedTimeProvider(run.StartedAt.AddSeconds(30)));
 
             // MaxClicks = 15 * 30 = 450, request 451
             await ((Func<Task>)(() => sut.ExecuteAsync(run.Id, new GoldDungeonClaimRequest(451)))).Should()
                 .ThrowAsync<BadRequestException>();
+        }
+    }
+
+    public class 만료된_런일_때
+    {
+        [Fact]
+        public async Task BadRequestException이_발생한다()
+        {
+            var runRepo = Substitute.For<IGoldDungeonRunRepository>();
+            var userProvider = Substitute.For<ICurrentUserProvider>();
+            userProvider.GetAccountId().Returns(1L);
+            var run = GoldDungeonRun.Create(accountId: 1L, durationSeconds: 30, maxClicksPerSecond: 15);
+            runRepo.FindByIdAsync(run.Id).Returns(run);
+
+            // ExpiresAt = StartedAt + 30 + 30(유예), 그 이후 시점에 claim
+            var sut = BuildSut(runRepo: runRepo, userProvider: userProvider,
+                timeProvider: FixedTimeProvider(run.ExpiresAt.AddSeconds(1)));
+
+            await ((Func<Task>)(() => sut.ExecuteAsync(run.Id, new GoldDungeonClaimRequest(10)))).Should()
+                .ThrowAsync<BadRequestException>();
+        }
+    }
+
+    public class 경과_시간_대비_클릭이_과도할_때
+    {
+        [Fact]
+        public async Task BadRequestException이_발생한다()
+        {
+            var runRepo = Substitute.For<IGoldDungeonRunRepository>();
+            var userProvider = Substitute.For<ICurrentUserProvider>();
+            userProvider.GetAccountId().Returns(1L);
+            var run = GoldDungeonRun.Create(accountId: 1L, durationSeconds: 30, maxClicksPerSecond: 15);
+            runRepo.FindByIdAsync(run.Id).Returns(run);
+
+            // 시작 2초 후 허용 상한은 2 * 15 = 30클릭, request 100
+            var sut = BuildSut(runRepo: runRepo, userProvider: userProvider,
+                timeProvider: FixedTimeProvider(run.StartedAt.AddSeconds(2)));
+
+            await ((Func<Task>)(() => sut.ExecuteAsync(run.Id, new GoldDungeonClaimRequest(100)))).Should()
+                .ThrowAsync<BadRequestException>();
+        }
+
+        [Fact]
+        public async Task 허용_상한과_동일한_클릭은_예외가_발생하지_않는다()
+        {
+            // Arrange
+            var runRepo = Substitute.For<IGoldDungeonRunRepository>();
+            var userProvider = Substitute.For<ICurrentUserProvider>();
+            var playerRepo = Substitute.For<IPlayerRepository>();
+            var resourceRepo = Substitute.For<IPlayerResourceRepository>();
+            var stageRepo = Substitute.For<IPlayerStageRepository>();
+            var sessionRepo = Substitute.For<IPlayerSessionRepository>();
+            var weaponRepo = Substitute.For<IPlayerWeaponRepository>();
+            var skillRepo = Substitute.For<IPlayerSkillRepository>();
+            var txRunner = Substitute.For<IAppDbTransactionRunner>();
+            userProvider.GetAccountId().Returns(1L);
+            var run = GoldDungeonRun.Create(accountId: 1L, durationSeconds: 30, maxClicksPerSecond: 15);
+            runRepo.FindByIdAsync(run.Id).Returns(run);
+            // 2초 경과 → maxAllowedClicks = Ceiling(2 * 450 / 30) = 30, clicks=30 은 허용
+            SetupPlayerData(playerRepo, resourceRepo, stageRepo, sessionRepo, weaponRepo, skillRepo);
+            txRunner.ExecuteAsync(Arg.Any<Func<Task>>())
+                .Returns(callInfo => callInfo.Arg<Func<Task>>()());
+
+            var sut = BuildSut(playerRepo: playerRepo, resourceRepo: resourceRepo,
+                stageRepo: stageRepo, sessionRepo: sessionRepo,
+                weaponRepo: weaponRepo, skillRepo: skillRepo,
+                runRepo: runRepo, txRunner: txRunner, userProvider: userProvider,
+                timeProvider: FixedTimeProvider(run.StartedAt.AddSeconds(2)));
+
+            // Act
+            Func<Task> act = () => sut.ExecuteAsync(run.Id, new GoldDungeonClaimRequest(30));
+
+            // Assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task t0에서_클릭0은_예외가_발생하지_않는다()
+        {
+            // Arrange
+            var runRepo = Substitute.For<IGoldDungeonRunRepository>();
+            var userProvider = Substitute.For<ICurrentUserProvider>();
+            var playerRepo = Substitute.For<IPlayerRepository>();
+            var resourceRepo = Substitute.For<IPlayerResourceRepository>();
+            var stageRepo = Substitute.For<IPlayerStageRepository>();
+            var sessionRepo = Substitute.For<IPlayerSessionRepository>();
+            var weaponRepo = Substitute.For<IPlayerWeaponRepository>();
+            var skillRepo = Substitute.For<IPlayerSkillRepository>();
+            var txRunner = Substitute.For<IAppDbTransactionRunner>();
+            userProvider.GetAccountId().Returns(1L);
+            var run = GoldDungeonRun.Create(accountId: 1L, durationSeconds: 30, maxClicksPerSecond: 15);
+            runRepo.FindByIdAsync(run.Id).Returns(run);
+            // elapsedSeconds=0 → maxAllowedClicks=0, clicks=0 은 허용
+            SetupPlayerData(playerRepo, resourceRepo, stageRepo, sessionRepo, weaponRepo, skillRepo);
+            txRunner.ExecuteAsync(Arg.Any<Func<Task>>())
+                .Returns(callInfo => callInfo.Arg<Func<Task>>()());
+
+            var sut = BuildSut(playerRepo: playerRepo, resourceRepo: resourceRepo,
+                stageRepo: stageRepo, sessionRepo: sessionRepo,
+                weaponRepo: weaponRepo, skillRepo: skillRepo,
+                runRepo: runRepo, txRunner: txRunner, userProvider: userProvider,
+                timeProvider: FixedTimeProvider(run.StartedAt));
+
+            // Act
+            Func<Task> act = () => sut.ExecuteAsync(run.Id, new GoldDungeonClaimRequest(0));
+
+            // Assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task t0에서_클릭1은_BadRequestException이_발생한다()
+        {
+            // Arrange
+            var runRepo = Substitute.For<IGoldDungeonRunRepository>();
+            var userProvider = Substitute.For<ICurrentUserProvider>();
+            userProvider.GetAccountId().Returns(1L);
+            var run = GoldDungeonRun.Create(accountId: 1L, durationSeconds: 30, maxClicksPerSecond: 15);
+            runRepo.FindByIdAsync(run.Id).Returns(run);
+            // elapsedSeconds=0 → maxAllowedClicks=0, clicks=1 은 거부
+
+            var sut = BuildSut(runRepo: runRepo, userProvider: userProvider,
+                timeProvider: FixedTimeProvider(run.StartedAt));
+
+            // Act
+            Func<Task> act = () => sut.ExecuteAsync(run.Id, new GoldDungeonClaimRequest(1));
+
+            // Assert
+            await act.Should().ThrowAsync<BadRequestException>();
+        }
+    }
+
+    public class 만료_경계_케이스
+    {
+        [Fact]
+        public async Task ExpiresAt_정각에는_예외가_발생하지_않는다()
+        {
+            // Arrange
+            var runRepo = Substitute.For<IGoldDungeonRunRepository>();
+            var userProvider = Substitute.For<ICurrentUserProvider>();
+            var playerRepo = Substitute.For<IPlayerRepository>();
+            var resourceRepo = Substitute.For<IPlayerResourceRepository>();
+            var stageRepo = Substitute.For<IPlayerStageRepository>();
+            var sessionRepo = Substitute.For<IPlayerSessionRepository>();
+            var weaponRepo = Substitute.For<IPlayerWeaponRepository>();
+            var skillRepo = Substitute.For<IPlayerSkillRepository>();
+            var txRunner = Substitute.For<IAppDbTransactionRunner>();
+            userProvider.GetAccountId().Returns(1L);
+            var run = GoldDungeonRun.Create(accountId: 1L, durationSeconds: 30, maxClicksPerSecond: 15);
+            runRepo.FindByIdAsync(run.Id).Returns(run);
+            // now == ExpiresAt → now > ExpiresAt 은 false → 만료 아님
+            // elapsedSeconds = Clamp(60, 0, 30) = 30, maxAllowedClicks = 450, clicks=100 허용
+            SetupPlayerData(playerRepo, resourceRepo, stageRepo, sessionRepo, weaponRepo, skillRepo);
+            txRunner.ExecuteAsync(Arg.Any<Func<Task>>())
+                .Returns(callInfo => callInfo.Arg<Func<Task>>()());
+
+            var sut = BuildSut(playerRepo: playerRepo, resourceRepo: resourceRepo,
+                stageRepo: stageRepo, sessionRepo: sessionRepo,
+                weaponRepo: weaponRepo, skillRepo: skillRepo,
+                runRepo: runRepo, txRunner: txRunner, userProvider: userProvider,
+                timeProvider: FixedTimeProvider(run.ExpiresAt));
+
+            // Act
+            Func<Task> act = () => sut.ExecuteAsync(run.Id, new GoldDungeonClaimRequest(100));
+
+            // Assert
+            await act.Should().NotThrowAsync();
         }
     }
 
@@ -166,6 +343,7 @@ public class GoldDungeonClaimServiceTest
         private readonly IAppDbTransactionRunner _txRunner = Substitute.For<IAppDbTransactionRunner>();
         private readonly ICurrentUserProvider _currentUserProvider = Substitute.For<ICurrentUserProvider>();
         private readonly GoldDungeonRun _run;
+        private readonly TimeProvider _timeProvider;
 
         public 정상_클레임_요청시()
         {
@@ -173,6 +351,7 @@ public class GoldDungeonClaimServiceTest
             _run = GoldDungeonRun.Create(accountId: 1L, durationSeconds: 30, maxClicksPerSecond: 15);
             _runRepository.FindByIdAsync(_run.Id).Returns(_run);
             _randomProvider.Next(0, 100).Returns(50); // >= 2, no mithril
+            _timeProvider = FixedTimeProvider(_run.StartedAt.AddSeconds(30));
             SetupPlayerData(_playerRepository, _resourceRepository, _stageRepository,
                 _sessionRepository, _weaponRepository, _skillRepository);
             _txRunner.ExecuteAsync(Arg.Any<Func<Task>>())
@@ -186,7 +365,8 @@ public class GoldDungeonClaimServiceTest
                 stageRepo: _stageRepository, sessionRepo: _sessionRepository,
                 weaponRepo: _weaponRepository, skillRepo: _skillRepository,
                 redisRepo: _redisRepository, runRepo: _runRepository,
-                randomProvider: _randomProvider, txRunner: _txRunner, userProvider: _currentUserProvider);
+                randomProvider: _randomProvider, txRunner: _txRunner, userProvider: _currentUserProvider,
+                timeProvider: _timeProvider);
 
             var result = await sut.ExecuteAsync(_run.Id, new GoldDungeonClaimRequest(100));
 
@@ -200,7 +380,8 @@ public class GoldDungeonClaimServiceTest
                 stageRepo: _stageRepository, sessionRepo: _sessionRepository,
                 weaponRepo: _weaponRepository, skillRepo: _skillRepository,
                 redisRepo: _redisRepository, runRepo: _runRepository,
-                randomProvider: _randomProvider, txRunner: _txRunner, userProvider: _currentUserProvider);
+                randomProvider: _randomProvider, txRunner: _txRunner, userProvider: _currentUserProvider,
+                timeProvider: _timeProvider);
 
             await sut.ExecuteAsync(_run.Id, new GoldDungeonClaimRequest(100));
 
@@ -222,6 +403,7 @@ public class GoldDungeonClaimServiceTest
         private readonly IAppDbTransactionRunner _txRunner = Substitute.For<IAppDbTransactionRunner>();
         private readonly ICurrentUserProvider _currentUserProvider = Substitute.For<ICurrentUserProvider>();
         private readonly GoldDungeonRun _run;
+        private readonly TimeProvider _timeProvider;
 
         public 동시_claim으로_저장_트랜잭션이_충돌할_때()
         {
@@ -229,6 +411,7 @@ public class GoldDungeonClaimServiceTest
             _run = GoldDungeonRun.Create(accountId: 1L, durationSeconds: 30, maxClicksPerSecond: 15);
             _runRepository.FindByIdAsync(_run.Id).Returns(_run);
             _randomProvider.Next(0, 100).Returns(50);
+            _timeProvider = FixedTimeProvider(_run.StartedAt.AddSeconds(30));
             SetupPlayerData(_playerRepository, _resourceRepository, _stageRepository,
                 _sessionRepository, _weaponRepository, _skillRepository);
             // xmin 충돌 → AppDbTransactionRunner가 ConflictException으로 변환한 상황
@@ -241,7 +424,8 @@ public class GoldDungeonClaimServiceTest
             stageRepo: _stageRepository, sessionRepo: _sessionRepository,
             weaponRepo: _weaponRepository, skillRepo: _skillRepository,
             redisRepo: _redisRepository, runRepo: _runRepository,
-            randomProvider: _randomProvider, txRunner: _txRunner, userProvider: _currentUserProvider);
+            randomProvider: _randomProvider, txRunner: _txRunner, userProvider: _currentUserProvider,
+            timeProvider: _timeProvider);
 
         [Fact]
         public async Task ConflictException이_전파된다()

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -362,21 +362,21 @@ public record SkillUnlockResponse(bool WasAlreadyUnlocked, ChangesDto Changes, P
 
 ### 보안 및 남용 방지
 
-- game API rate limit은 전역 fixed window가 아니라 account ID 기준 partition으로 적용한다.
-- 로그인 전 API는 IP 기준 partition을 사용한다.
+- ~~game API rate limit은 전역 fixed window가 아니라 account ID 기준 partition으로 적용한다.~~ → *`RateLimitConfig`의 `game` 정책 (account `sub` claim 기준)*
+- ~~로그인 전 API는 IP 기준 partition을 사용한다.~~ → *`RateLimitConfig`의 `login` 정책 (IP 기준)*
 - claim 계열 API는 같은 account에 대해 짧은 시간 중복 호출될 수 있으므로 rate limit과 멱등성 정책을 함께 설계한다.
-- gold dungeon 클릭 수 검증은 `clicks <= maxClicks`만으로 충분하지 않다. 너무 이른 claim과 run 시작/종료 시간을 같이 검증한다.
+- ~~gold dungeon 클릭 수 검증은 `clicks <= maxClicks`만으로 충분하지 않다. 너무 이른 claim과 run 시작/종료 시간을 같이 검증한다.~~ → *경과 시간 기반 클릭 상한 검증 추가 (`TimeProvider` 주입)*
 - 서버 권위 전환 후에도 클라이언트 조작 가능 값이 요청 DTO에 남아 있는지 route/request audit을 한다.
 
 ### 마이그레이션 및 시드
 
-- `players.account_id` unique constraint 추가
-- `players`의 기존 `(account_id, job_type)` unique index 제거
-- `account_dungeon_ticket`, `gold_dungeon_run` 테이블 migration 추가
+- ~~`players.account_id` unique constraint 추가~~ → *`PlayerSinglePerAccount` 마이그레이션*
+- ~~`players`의 기존 `(account_id, job_type)` unique index 제거~~ → *`PlayerSinglePerAccount` 마이그레이션*
+- ~~`account_dungeon_ticket`, `gold_dungeon_run` 테이블 migration 추가~~ → *`AddDungeonTicketAndGoldRun` 마이그레이션*
 - ~~게임 데이터 조회 API에서 필요한 표시 필드가 부족하면 `SkillData`, `WeaponData`에 이름/설명 필드 추가 여부 결정~~ → *추가하지 않음으로 결정 (클라이언트가 표시 텍스트 보유)*
 - ~~seed 경로를 배포 이미지에서 실행 가능한 방식으로 정리~~ → *임베디드 JSON + `GameDataSeeder`로 구성, `docs/game-data-seeding.md` 참고*
 - ~~seed 데이터 중 스킬 선행 관계가 순환하지 않는지 검증 테스트 추가~~ → *`SkillSeedDataTests`*
-- KST 일일 보상 판정을 위해 저장 컬럼 타입을 `date`로 둘지 UTC timestamp로 둘지 확정
+- ~~KST 일일 보상 판정을 위해 저장 컬럼 타입을 `date`로 둘지 UTC timestamp로 둘지 확정~~ → *`DateOnly`(`date` 컬럼) + `Asia/Seoul` 판정으로 구현됨*
 - 추천 답: 판정 기준 날짜는 `LocalDate` 의미의 `date` 컬럼으로 저장하고, 계산은 서버에서 `Asia/Seoul` 기준으로 수행한다.
 
 ### 테스트 체크리스트


### PR DESCRIPTION
## 📚작업 내용

- 골드 던전 claim에 경과 시간 기반 클릭 상한 검증 추가 — 시작 직후 과도한 클릭 요청 차단, `TimeProvider` 주입으로 시간 의존 로직 테스트 가능화, 검증 테스트 7건 추가
- JWT `MapInboundClaims` 비활성화 — `sub` 등 원본 클레임 이름 보존
- `UseRateLimiter`를 `UseAuthentication` 뒤로 이동 — account ID 기준 rate limit partition이 실제로 동작하도록 수정
- 로깅·응답 래핑 제외 경로를 `/health`에서 `/v1/health`로 수정
- Production 환경에서 Swagger를 Basic Auth로 보호 — `Swagger__Password` 환경변수로 비밀번호 주입, 미설정 시 404 폴백
- prod compose에 DB·Redis healthcheck 추가, 서버 컨테이너는 `service_healthy` 조건으로 기동
- CD 배포 단계에 health 폴링 검증(최대 90초, 실패 시 워크플로우 실패), `.env` 권한 600, dangling 이미지 정리 추가
- test 스킬 빌드 경로 수정 및 TODO 완료 항목 정리

## ◀️참고 사항

- 배포 전 GitHub 시크릿 `SWAGGER_PASSWORD` 등록이 필요합니다 (등록 완료).
- TLS는 학교 서버 포트포워딩 제약(외부 443 확보 불가)으로 HTTP 유지로 확정했습니다.
- 빌드 및 전체 테스트 160건 통과 확인했습니다.

## ✅체크리스트

> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.

- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?


> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*
