### PR TITLE
fix: PR #24 배포 리뷰 코멘트 수정

### DIFF
--- a/Fantasy-server/Fantasy.Server/Domain/Account/Service/DeleteAccountService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Account/Service/DeleteAccountService.cs
@@ -14,6 +14,7 @@ public class DeleteAccountService : IDeleteAccountService
     private readonly IAccountRepository _accountRepository;
     private readonly ICurrentUserProvider _currentUserProvider;
     private readonly IPlayerRepository _playerRepository;
+    private readonly IPlayerRedisRepository _playerRedisRepository;
     private readonly IRefreshTokenRedisRepository _refreshTokenRepository;
     private readonly IAppDbTransactionRunner _txRunner;
 
@@ -21,12 +22,14 @@ public class DeleteAccountService : IDeleteAccountService
         IAccountRepository accountRepository,
         ICurrentUserProvider currentUserProvider,
         IPlayerRepository playerRepository,
+        IPlayerRedisRepository playerRedisRepository,
         IRefreshTokenRedisRepository refreshTokenRepository,
         IAppDbTransactionRunner txRunner)
     {
         _accountRepository = accountRepository;
         _currentUserProvider = currentUserProvider;
         _playerRepository = playerRepository;
+        _playerRedisRepository = playerRedisRepository;
         _refreshTokenRepository = refreshTokenRepository;
         _txRunner = txRunner;
     }
@@ -47,6 +50,7 @@ public class DeleteAccountService : IDeleteAccountService
             await _accountRepository.DeleteAsync(account);
         });
 
+        await _playerRedisRepository.DeleteAsync(account.Id);
         await _refreshTokenRepository.DeleteAsync(account.Id);
     }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Dto/Request/RefreshTokenRequest.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Dto/Request/RefreshTokenRequest.cs
@@ -1,5 +1,7 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Fantasy.Server.Domain.Auth.Dto.Request;
 
 public record RefreshTokenRequest(
-    string RefreshToken
+    [Required] string RefreshToken
 );

--- a/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/RefreshTokenRedisRepository.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Auth/Repository/RefreshTokenRedisRepository.cs
@@ -1,5 +1,6 @@
 using Fantasy.Server.Domain.Auth.Enum;
 using Fantasy.Server.Domain.Auth.Repository.Interface;
+using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
 namespace Fantasy.Server.Domain.Auth.Repository;
@@ -27,10 +28,12 @@ public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
     ");
 
     private readonly IDatabase _db;
+    private readonly ILogger<RefreshTokenRedisRepository> _logger;
 
-    public RefreshTokenRedisRepository(IConnectionMultiplexer multiplexer)
+    public RefreshTokenRedisRepository(IConnectionMultiplexer multiplexer, ILogger<RefreshTokenRedisRepository> logger)
     {
         _db = multiplexer.GetDatabase();
+        _logger = logger;
     }
 
     private static string ForwardKey(long id) => $"{Prefix}refresh:{id}";
@@ -59,5 +62,24 @@ public class RefreshTokenRedisRepository : IRefreshTokenRedisRepository
     }
 
     public async Task DeleteAsync(long id)
-        => await _db.KeyDeleteAsync(ForwardKey(id));
+    {
+        var key = ForwardKey(id);
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            try
+            {
+                await _db.KeyDeleteAsync(key);
+                return;
+            }
+            catch (RedisException ex) when (attempt < 3)
+            {
+                _logger.LogWarning(ex, "RefreshToken 캐시 삭제 실패 (시도 {Attempt}/3, key={Key})", attempt, key);
+                await Task.Delay(100 * attempt);
+            }
+            catch (RedisException ex)
+            {
+                _logger.LogError(ex, "RefreshToken 캐시 삭제 최종 실패 (key={Key}). DB가 정상 업데이트됐으므로 계속 진행.", key);
+            }
+        }
+    }
 }

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/BossDungeonService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/BossDungeonService.cs
@@ -27,6 +27,7 @@ public class BossDungeonService : IBossDungeonService
     private readonly IGameDataCacheService _gameDataCacheService;
     private readonly ILevelUpService _levelUpService;
     private readonly IAppDbTransactionRunner _transactionRunner;
+    private readonly IRandomProvider _randomProvider;
     private readonly ICurrentUserProvider _currentUserProvider;
     private readonly ICombatStatCalculator _calculator;
 
@@ -41,6 +42,7 @@ public class BossDungeonService : IBossDungeonService
         IGameDataCacheService gameDataCacheService,
         ILevelUpService levelUpService,
         IAppDbTransactionRunner transactionRunner,
+        IRandomProvider randomProvider,
         ICurrentUserProvider currentUserProvider,
         ICombatStatCalculator calculator)
     {
@@ -54,6 +56,7 @@ public class BossDungeonService : IBossDungeonService
         _gameDataCacheService = gameDataCacheService;
         _levelUpService = levelUpService;
         _transactionRunner = transactionRunner;
+        _randomProvider = randomProvider;
         _currentUserProvider = currentUserProvider;
         _calculator = calculator;
     }
@@ -123,7 +126,7 @@ public class BossDungeonService : IBossDungeonService
 
         if (aJobWeapons.Count > 0)
         {
-            var dropped = aJobWeapons[Random.Shared.Next(aJobWeapons.Count)];
+            var dropped = aJobWeapons[_randomProvider.Next(0, aJobWeapons.Count)];
             droppedWeapon = new DroppedWeaponInfo(dropped.WeaponId, dropped.Name, dropped.Grade);
 
             var existing = weapons.FirstOrDefault(w => w.WeaponId == dropped.WeaponId);

--- a/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/WeaponDungeonService.cs
+++ b/Fantasy-server/Fantasy.Server/Domain/Dungeon/Service/WeaponDungeonService.cs
@@ -5,6 +5,7 @@ using Fantasy.Server.Domain.GameData.Enum;
 using Fantasy.Server.Domain.GameData.Service.Interface;
 using Fantasy.Server.Domain.Player.Dto.Request;
 using Fantasy.Server.Domain.Player.Repository.Interface;
+using Fantasy.Server.Global.Infrastructure;
 using Fantasy.Server.Global.Security.Provider;
 using Gamism.SDK.Extensions.AspNetCore.Exceptions;
 
@@ -24,6 +25,8 @@ public class WeaponDungeonService : IWeaponDungeonService
     private readonly IPlayerSkillRepository _playerSkillRepository;
     private readonly IPlayerRedisRepository _playerRedisRepository;
     private readonly IGameDataCacheService _gameDataCacheService;
+    private readonly IAppDbTransactionRunner _transactionRunner;
+    private readonly IRandomProvider _randomProvider;
     private readonly ICurrentUserProvider _currentUserProvider;
     private readonly ICombatStatCalculator _calculator;
 
@@ -36,6 +39,8 @@ public class WeaponDungeonService : IWeaponDungeonService
         IPlayerSkillRepository playerSkillRepository,
         IPlayerRedisRepository playerRedisRepository,
         IGameDataCacheService gameDataCacheService,
+        IAppDbTransactionRunner transactionRunner,
+        IRandomProvider randomProvider,
         ICurrentUserProvider currentUserProvider,
         ICombatStatCalculator calculator)
     {
@@ -47,6 +52,8 @@ public class WeaponDungeonService : IWeaponDungeonService
         _playerSkillRepository = playerSkillRepository;
         _playerRedisRepository = playerRedisRepository;
         _gameDataCacheService = gameDataCacheService;
+        _transactionRunner = transactionRunner;
+        _randomProvider = randomProvider;
         _currentUserProvider = currentUserProvider;
         _calculator = calculator;
     }
@@ -106,30 +113,30 @@ public class WeaponDungeonService : IWeaponDungeonService
         if (cleared)
         {
             // B등급 드랍 시도
-            if (Random.Shared.Next(0, 100) < BGradeDropRatePercent)
+            if (_randomProvider.Next(0, 100) < BGradeDropRatePercent)
             {
                 var bWeapons = await _gameDataCacheService.GetWeaponDataByGradeAsync(WeaponGrade.B);
                 var bJobWeapons = bWeapons.Where(w => w.JobType == jobType).ToList();
                 if (bJobWeapons.Count > 0)
                 {
-                    var dropped = bJobWeapons[Random.Shared.Next(bJobWeapons.Count)];
+                    var dropped = bJobWeapons[_randomProvider.Next(0, bJobWeapons.Count)];
                     droppedWeapons.Add(new DroppedWeaponInfo(dropped.WeaponId, dropped.Name, dropped.Grade));
                 }
             }
             // C등급 드랍 시도
-            if (Random.Shared.Next(0, 100) < CGradeDropRatePercent)
+            if (_randomProvider.Next(0, 100) < CGradeDropRatePercent)
             {
                 var cWeapons = await _gameDataCacheService.GetWeaponDataByGradeAsync(WeaponGrade.C);
                 var cJobWeapons = cWeapons.Where(w => w.JobType == jobType).ToList();
                 if (cJobWeapons.Count > 0)
                 {
-                    var dropped = cJobWeapons[Random.Shared.Next(cJobWeapons.Count)];
+                    var dropped = cJobWeapons[_randomProvider.Next(0, cJobWeapons.Count)];
                     droppedWeapons.Add(new DroppedWeaponInfo(dropped.WeaponId, dropped.Name, dropped.Grade));
                 }
             }
 
             // 스크롤 드랍 시도
-            if (Random.Shared.Next(0, 100) < ScrollDropRatePercent)
+            if (_randomProvider.Next(0, 100) < ScrollDropRatePercent)
                 droppedScrolls = 1;
         }
 
@@ -144,14 +151,17 @@ public class WeaponDungeonService : IWeaponDungeonService
                 })
                 .ToList();
 
-            if (weaponChanges.Count > 0)
-                await _playerWeaponRepository.UpsertRangeAsync(player.Id, weaponChanges);
-
             if (droppedScrolls > 0)
-            {
                 resource.UpdateChangeData(resource.EnhancementScroll + droppedScrolls, null, null);
-                await _playerResourceRepository.UpdateAsync(resource);
-            }
+
+            await _transactionRunner.ExecuteAsync(async () =>
+            {
+                if (weaponChanges.Count > 0)
+                    await _playerWeaponRepository.UpsertRangeAsync(player.Id, weaponChanges);
+
+                if (droppedScrolls > 0)
+                    await _playerResourceRepository.UpdateAsync(resource);
+            });
 
             await _playerRedisRepository.DeleteAsync(accountId);
         }

--- a/Fantasy-server/Fantasy.Server/Global/Config/JwtConfig.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Config/JwtConfig.cs
@@ -33,7 +33,8 @@ public static class JwtConfig
                 ValidIssuer = issuer,
                 ValidAudience = audience,
                 IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secretKey)),
-                ClockSkew = TimeSpan.Zero
+                ClockSkew = TimeSpan.Zero,
+                RoleClaimType = "role"
             };
         });
 

--- a/Fantasy-server/Fantasy.Server/Global/Security/Jwt/JwtProvider.cs
+++ b/Fantasy-server/Fantasy.Server/Global/Security/Jwt/JwtProvider.cs
@@ -34,7 +34,7 @@ public class JwtProvider : IJwtProvider
         {
             new Claim(JwtRegisteredClaimNames.Sub, account.Id.ToString()),
             new Claim(JwtRegisteredClaimNames.Email, account.Email),
-            new Claim(ClaimTypes.Role, account.Role.ToString()),
+            new Claim("role", account.Role.ToString()),
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
             new Claim(JwtRegisteredClaimNames.Iat,
                 DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(),

--- a/Fantasy-server/Fantasy.Test/Account/Service/DeleteAccountServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Account/Service/DeleteAccountServiceTests.cs
@@ -34,6 +34,7 @@ public class DeleteAccountServiceTests
         private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
         private readonly ICurrentUserProvider _currentUserProvider = Substitute.For<ICurrentUserProvider>();
         private readonly IPlayerRepository _playerRepository = Substitute.For<IPlayerRepository>();
+        private readonly IPlayerRedisRepository _playerRedisRepository = Substitute.For<IPlayerRedisRepository>();
         private readonly IRefreshTokenRedisRepository _refreshTokenRepository = Substitute.For<IRefreshTokenRedisRepository>();
         private readonly IAppDbTransactionRunner _txRunner = CreateTxRunner();
         private readonly DeleteAccountService _sut;
@@ -46,7 +47,7 @@ public class DeleteAccountServiceTests
             _accountRepository.FindByEmailAsync(Email).Returns(_account);
             _sut = new DeleteAccountService(
                 _accountRepository, _currentUserProvider,
-                _playerRepository, _refreshTokenRepository, _txRunner);
+                _playerRepository, _playerRedisRepository, _refreshTokenRepository, _txRunner);
         }
 
         [Fact]
@@ -72,6 +73,14 @@ public class DeleteAccountServiceTests
 
             await _refreshTokenRepository.Received(1).DeleteAsync(_account.Id);
         }
+
+        [Fact]
+        public async Task 회원탈퇴_요청_시_Player_캐시가_삭제된다()
+        {
+            await _sut.ExecuteAsync(_request);
+
+            await _playerRedisRepository.Received(1).DeleteAsync(_account.Id);
+        }
     }
 
     public class 존재하지_않는_계정으로_탈퇴_요청할_때
@@ -79,6 +88,7 @@ public class DeleteAccountServiceTests
         private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
         private readonly ICurrentUserProvider _currentUserProvider = Substitute.For<ICurrentUserProvider>();
         private readonly IPlayerRepository _playerRepository = Substitute.For<IPlayerRepository>();
+        private readonly IPlayerRedisRepository _playerRedisRepository = Substitute.For<IPlayerRedisRepository>();
         private readonly IRefreshTokenRedisRepository _refreshTokenRepository = Substitute.For<IRefreshTokenRedisRepository>();
         private readonly IAppDbTransactionRunner _txRunner = CreateTxRunner();
         private readonly DeleteAccountService _sut;
@@ -90,7 +100,7 @@ public class DeleteAccountServiceTests
             _accountRepository.FindByEmailAsync(Email).Returns((AccountEntity?)null);
             _sut = new DeleteAccountService(
                 _accountRepository, _currentUserProvider,
-                _playerRepository, _refreshTokenRepository, _txRunner);
+                _playerRepository, _playerRedisRepository, _refreshTokenRepository, _txRunner);
         }
 
         [Fact]
@@ -107,6 +117,7 @@ public class DeleteAccountServiceTests
         private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
         private readonly ICurrentUserProvider _currentUserProvider = Substitute.For<ICurrentUserProvider>();
         private readonly IPlayerRepository _playerRepository = Substitute.For<IPlayerRepository>();
+        private readonly IPlayerRedisRepository _playerRedisRepository = Substitute.For<IPlayerRedisRepository>();
         private readonly IRefreshTokenRedisRepository _refreshTokenRepository = Substitute.For<IRefreshTokenRedisRepository>();
         private readonly IAppDbTransactionRunner _txRunner = CreateTxRunner();
         private readonly DeleteAccountService _sut;
@@ -119,7 +130,7 @@ public class DeleteAccountServiceTests
             _accountRepository.FindByEmailAsync(Email).Returns(_account);
             _sut = new DeleteAccountService(
                 _accountRepository, _currentUserProvider,
-                _playerRepository, _refreshTokenRepository, _txRunner);
+                _playerRepository, _playerRedisRepository, _refreshTokenRepository, _txRunner);
         }
 
         [Fact]

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/BossDungeonServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/BossDungeonServiceTests.cs
@@ -30,6 +30,7 @@ public class BossDungeonServiceTests
         IGameDataCacheService? cache = null,
         ILevelUpService? levelUpService = null,
         IAppDbTransactionRunner? txRunner = null,
+        IRandomProvider? randomProvider = null,
         ICurrentUserProvider? userProvider = null,
         ICombatStatCalculator? calculator = null)
     {
@@ -43,13 +44,14 @@ public class BossDungeonServiceTests
         cache ??= Substitute.For<IGameDataCacheService>();
         levelUpService ??= Substitute.For<ILevelUpService>();
         txRunner ??= Substitute.For<IAppDbTransactionRunner>();
+        randomProvider ??= Substitute.For<IRandomProvider>();
         userProvider ??= Substitute.For<ICurrentUserProvider>();
         calculator ??= new CombatStatCalculator();
 
         return new BossDungeonService(
             playerRepo, resourceRepo, stageRepo, sessionRepo,
             weaponRepo, skillRepo, redisRepo, cache,
-            levelUpService, txRunner, userProvider, calculator);
+            levelUpService, txRunner, randomProvider, userProvider, calculator);
     }
 
     public class 플레이어가_없을_때

--- a/Fantasy-server/Fantasy.Test/Dungeon/Service/WeaponDungeonServiceTests.cs
+++ b/Fantasy-server/Fantasy.Test/Dungeon/Service/WeaponDungeonServiceTests.cs
@@ -6,6 +6,7 @@ using Fantasy.Server.Domain.GameData.Service.Interface;
 using Fantasy.Server.Domain.Player.Entity;
 using Fantasy.Server.Domain.Player.Enum;
 using Fantasy.Server.Domain.Player.Repository.Interface;
+using Fantasy.Server.Global.Infrastructure;
 using Fantasy.Server.Global.Security.Provider;
 using FluentAssertions;
 using Gamism.SDK.Extensions.AspNetCore.Exceptions;
@@ -26,6 +27,8 @@ public class WeaponDungeonServiceTests
         IPlayerSkillRepository? skillRepo = null,
         IPlayerRedisRepository? redisRepo = null,
         IGameDataCacheService? cache = null,
+        IAppDbTransactionRunner? txRunner = null,
+        IRandomProvider? randomProvider = null,
         ICurrentUserProvider? userProvider = null,
         ICombatStatCalculator? calculator = null)
     {
@@ -37,13 +40,23 @@ public class WeaponDungeonServiceTests
         skillRepo ??= Substitute.For<IPlayerSkillRepository>();
         redisRepo ??= Substitute.For<IPlayerRedisRepository>();
         cache ??= Substitute.For<IGameDataCacheService>();
+        txRunner ??= CreateTxRunner();
+        randomProvider ??= Substitute.For<IRandomProvider>();
         userProvider ??= Substitute.For<ICurrentUserProvider>();
         calculator ??= new CombatStatCalculator();
 
         return new WeaponDungeonService(
             playerRepo, resourceRepo, stageRepo, sessionRepo,
             weaponRepo, skillRepo, redisRepo, cache,
-            userProvider, calculator);
+            txRunner, randomProvider, userProvider, calculator);
+    }
+
+    private static IAppDbTransactionRunner CreateTxRunner()
+    {
+        var txRunner = Substitute.For<IAppDbTransactionRunner>();
+        txRunner.ExecuteAsync(Arg.Any<Func<Task>>())
+            .Returns(ci => ci.Arg<Func<Task>>()());
+        return txRunner;
     }
 
     public class 플레이어가_없을_때


### PR DESCRIPTION
## 개요

배포 PR #24 의 코드 리뷰 코멘트(gemini-code-assist)를 반영한 수정 PR입니다.
릴리스 브랜치에 직접 커밋하지 않고 별도 bugfix 브랜치로 작업했으며, base 를 `release/1.0.0` 으로 두어 머지 시 **1.0.0 릴리스에 수정이 포함**되도록 했습니다.

대상 리뷰: #24

## 수정 내역

| 심각도 | 항목 | 변경 |
|---|---|---|
| 🔴 HIGH | JWT role 인가 | 토큰 발급 클레임을 `ClaimTypes.Role`(긴 URI) → 표준 `"role"` 로 변경하고, `MapInboundClaims=false` 환경에서 인가가 동작하도록 `TokenValidationParameters.RoleClaimType="role"` 추가 (기존 `sub`/`email` 과 동일하게 짧은 표준 이름으로 일관화) |
| 🔴 HIGH | 회원 탈퇴 캐시 정합성 | 탈퇴 시 `IPlayerRedisRepository` 를 주입받아 `fantasy:player:{accountId}` 캐시를 함께 삭제 (DB 삭제 후 캐시 무효화) |
| 🔴 HIGH | 무기 던전 보상 원자성 | 무기 upsert + 강화 주문서 갱신을 `IAppDbTransactionRunner` 트랜잭션으로 묶음 (BossDungeonService 와 동일 패턴, Redis 무효화는 트랜잭션 밖 유지) |
| 🟡 MED | RefreshToken 검증 | `RefreshTokenRequest.RefreshToken` 에 `[Required]` 추가 (누락 시 500 → 400) |
| 🟡 MED | 테스트 용이성 | `WeaponDungeonService` / `BossDungeonService` 의 `Random.Shared` → 기등록된 `IRandomProvider` 주입으로 교체 |

## 테스트

- `DeleteAccountServiceTests` 에 Player 캐시 무효화 회귀 테스트 1건 추가
- 생성자 시그니처 변경에 맞춰 던전/계정 테스트 픽스처 갱신
- 빌드 성공, 전체 **161개 테스트 통과**

## 참고

- `#1` 리뷰 코멘트(JWT)는 봇 제안(발급 측만 `"role"`)만으로는 불완전하여, 인가가 실제로 동작하도록 `RoleClaimType` 설정을 함께 적용했습니다.
