### PR TITLE
fix: EF 모델 동기화 마이그레이션 추가 (PendingModelChangesWarning 해결)

### DIFF
--- a/Fantasy-server/Fantasy.Server/Migrations/20260625063557_SyncModelChanges.Designer.cs
+++ b/Fantasy-server/Fantasy.Server/Migrations/20260625063557_SyncModelChanges.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Fantasy.Server.Global.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Fantasy.Server.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260625063557_SyncModelChanges")]
+    partial class SyncModelChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Fantasy-server/Fantasy.Server/Migrations/20260625063557_SyncModelChanges.cs
+++ b/Fantasy-server/Fantasy.Server/Migrations/20260625063557_SyncModelChanges.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fantasy.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncModelChanges : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "player",
+                table: "player_stage",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "player",
+                table: "player_session",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "player",
+                table: "player_resource",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "dungeon",
+                table: "gold_dungeon_run",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "dungeon",
+                table: "account_dungeon_ticket",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "player",
+                table: "player_stage");
+
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "player",
+                table: "player_session");
+
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "player",
+                table: "player_resource");
+
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "dungeon",
+                table: "gold_dungeon_run");
+
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "dungeon",
+                table: "account_dungeon_ticket");
+        }
+    }
+}


### PR DESCRIPTION
## 배경
prod CD의 `Deploy via Docker Compose` 단계에서 앱 컨테이너가 시작 직후 크래시.

```
System.InvalidOperationException: ... 'PendingModelChangesWarning':
The model for context 'AppDbContext' has pending changes.
```

`Program.cs`의 `db.Database.MigrateAsync()`가 모델 검증 중 누락된 마이그레이션을 감지해 예외를 던짐.

## 원인
xmin 동시성 토큰(`PlayerResource/PlayerSession/PlayerStage/AccountDungeonTicket/GoldDungeonRun`)이 엔티티에는 설정됐으나, 해당 모델 상태를 담은 마이그레이션이 없었음.

## 변경
- `SyncModelChanges` 마이그레이션 추가
- 엔티티 설정은 변경 없음(기존 설정이 Npgsql 정식 패턴)

## 안전성
`xmin`은 Npgsql이 PostgreSQL 시스템 컬럼으로 처리하므로 실제 생성 SQL은 history insert 한 줄뿐. 기존 데이터/스키마 영향 없음.

검증: 빌드 성공, 테스트 161개 전부 통과.