### PR TITLE
release/1.0.1

### DIFF
--- a/Fantasy-server/Fantasy.Server/Migrations/20260625063557_SyncModelChanges.Designer.cs
+++ b/Fantasy-server/Fantasy.Server/Migrations/20260625063557_SyncModelChanges.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Fantasy.Server.Global.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Fantasy.Server.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260625063557_SyncModelChanges")]
+    partial class SyncModelChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Fantasy-server/Fantasy.Server/Migrations/20260625063557_SyncModelChanges.cs
+++ b/Fantasy-server/Fantasy.Server/Migrations/20260625063557_SyncModelChanges.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fantasy.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncModelChanges : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "player",
+                table: "player_stage",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "player",
+                table: "player_session",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "player",
+                table: "player_resource",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "dungeon",
+                table: "gold_dungeon_run",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                schema: "dungeon",
+                table: "account_dungeon_ticket",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "player",
+                table: "player_stage");
+
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "player",
+                table: "player_session");
+
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "player",
+                table: "player_resource");
+
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "dungeon",
+                table: "gold_dungeon_run");
+
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                schema: "dungeon",
+                table: "account_dungeon_ticket");
+        }
+    }
+}


### PR DESCRIPTION
## 수정내역

- EF 모델 동기화 마이그레이션 추가 (`SyncModelChanges`) — 시작 시 `PendingModelChangesWarning`으로 인한 prod 배포 실패 해결 (#26)

## 비고
스키마 변경 없음(xmin은 Npgsql 시스템 컬럼 처리). 빌드 성공, 테스트 161개 통과.
이 PR이 main에 머지되면 prod CD가 v1.0.1 태그를 생성하고 배포합니다.