### PR TITLE
chore: 의존성 업데이트 및 SQLite 취약점 패치

### DIFF
--- a/Fantasy-server/CLAUDE.md
+++ b/Fantasy-server/CLAUDE.md
@@ -23,7 +23,7 @@
 | `Microsoft.AspNetCore.Authentication.JwtBearer` | 10.0.5 | `/dotnet/docs` |
 | `System.IdentityModel.Tokens.Jwt` | 8.17.0 | `/dotnet/docs` |
 | `BCrypt.Net-Next` | 4.1.0 | — (no Context7 entry) |
-| `Gamism.SDK.Extensions.AspNetCore` | 0.2.8 | — (no Context7 entry) |
+| `Gamism.SDK.Extensions.AspNetCore` | 0.4.0 | — (no Context7 entry) |
 | `xunit.v3` | 3.2.2 | `/xunit/xunit.net` |
 | `NSubstitute` | 5.3.0 | `/nsubstitute/nsubstitute` |
 | `FluentAssertions` | 8.9.0 | `/fluentassertions/fluentassertions` |

--- a/Fantasy-server/Fantasy.Server/Fantasy.Server.csproj
+++ b/Fantasy-server/Fantasy.Server/Fantasy.Server.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
-        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.3.1" />
+        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
 <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">

--- a/Fantasy-server/Fantasy.Test/Fantasy.Test.csproj
+++ b/Fantasy-server/Fantasy.Test/Fantasy.Test.csproj
@@ -23,7 +23,7 @@
         </PackageReference>
 
         <PackageReference Include="FluentAssertions" Version="8.9.0" />
-        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.3.1" />
+        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/Fantasy-server/Fantasy.Test/Fantasy.Test.csproj
+++ b/Fantasy-server/Fantasy.Test/Fantasy.Test.csproj
@@ -26,6 +26,8 @@
         <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+        <!-- Override transitive SQLitePCLRaw 2.1.11 (GHSA-2m69-gcr7-jv3q) with patched 3.0.x -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
     </ItemGroup>
 


### PR DESCRIPTION
## 📚작업 내용

- Gamism.SDK.Extensions.AspNetCore 0.3.1 → 0.4.0 업데이트 (Fantasy.Server, Fantasy.Test)
- 트랜지티브 의존성 Gamism.SDK.Core도 0.4.0으로 함께 상향
- CLAUDE.md 기술 스택 표의 Gamism 버전 표기를 0.4.0으로 정정 (기존 0.2.8로 실제 버전과 불일치)
- SQLite 취약점(GHSA-2m69-gcr7-jv3q, High) 대응: 테스트 프로젝트에 SQLitePCLRaw.bundle_e_sqlite3 3.0.3 직접 참조를 추가해 취약한 트랜지티브 2.1.11을 override

## ◀️참고 사항

- Gamism 0.4.0은 릴리스 노트가 없어 빌드·테스트로 호환성을 확인함
- 취약점은 SQLitePCLRaw.lib.e_sqlite3 2.1.11 이하 범위이며 패치 버전은 3.0.0+ (최신 3.0.3). 최신 EF Core Sqlite(10.0.9)도 여전히 2.1.11을 참조하여 EF 버전 상향만으로는 해결되지 않아 직접 override 방식을 적용
- SQLite는 테스트 프로젝트에서만 사용되어 변경 범위를 Fantasy.Test로 한정
- 검증: 빌드 경고 0, 테스트 155개 전부 통과, NU1903 경고 제거 확인

## ✅체크리스트

> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.

- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?


> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*
